### PR TITLE
Visualize NFA with DOT language

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,12 @@ This will then write the graph into `some/path/and/filename.dot`.
 
 - After the DOT file is generated, you can convert it into a PNG image with Graphviz.
 ```shell
-dot -Tpng nfa.dot -O
+dot -Tpng nfa.dot -o nfa.png
 ```
-The PNG image will be located at `nfa.dot.png`.
+![The NFA of "(a|b)*abb"](https://imgur.com/WCbGHDu.png)
+> **Note**
+> The numbering of the states is related to the order of their creations.
+
 See the [command line documentation of Graphviz](https://graphviz.org/doc/info/command.html) to learn more.
 
 ## 🚀 Development <a name = "development"></a>

--- a/README.md
+++ b/README.md
@@ -65,21 +65,37 @@ $ bin/regexp -h # or --help
 ```
 regexp
 
-Usage: regexp [options] [regexp string]
+Usage: regexp [-h] [-V] [-d regexp [-o FILE]] [regexp string]
 
 Description: Regular expression implementation.
 Supports only ( | ) * + ?. No escapes.
 Compiles to NFA and then simulates NFA using Thompson's algorithm.
 
-Matches the string (string) to the regular expression (regexp) and exits with 1 if it does not match.
+One can either graph the regexp or match a string.
+See the following options.
 
 Options:
+  -h, --help            Shows this help message and exit
+  -V, --version         Shows regexp version and exit
 
-        -v, --version
-                Prints regexp version
+Graph mode:
+  Converts the regular expression into a graph,
+  exits with 1 if regexp is ill-formed or the file can't be opened
 
-        -h, --help
-                Prints this help message
+  -d, --graph           Converts the NFA of the regexp into a Graphviz
+                        dot file (default: False)
+  -o FILE, --output FILE
+                        The name of the dot file.
+                        A .dot extension is appended automatically
+                        (default: nfa)
+  regexp                The regular expression to be converted
+
+Match mode:
+  Matches the string with the regular expression,
+  exits with 1 if regexp is ill-formed or it does not match
+
+  regexp                The regular expression to use on matching
+  string                The string to be matched
 
 Written by: Lai-YT
 
@@ -87,6 +103,9 @@ regexp version: 0.0.1
 ```
 
 ### Example
+
+#### Match mode
+This is the default mode. \
 _regexp_ takes two arguments: a regular expression and a string to match.
 ```shell
 $ bin/regexp '(a|b)*abb' 'bababb'
@@ -97,6 +116,32 @@ You can check the exit code with the following command if you're on an Unix shel
 ```shell
 $ echo $?
 ```
+
+#### Graph mode
+_regexp_ uses [Graphviz](https://graphviz.org/) to graph the NFA of a regular expression. It represents the NFA with the [DOT language](https://graphviz.org/doc/info/lang.html).
+
+By setting the `--graph` (or `-g`) option, you can use the graph mode. This takes a single regular expression as an argument.
+
+- Convert the NFA of a regular expression into a DOT file,
+```shell
+$ bin/regexp --graph '(a|b)*abb'
+```
+By default, the DOT file is written into `nfa.dot`.
+
+- You can also specify the output file with the `--output` (or `-o`) option, which takes a file as an argument.
+```shell
+$ bin/regexp --graph '(a|b)*abb' --output 'some/path/and/filename'
+```
+This will then write the graph into `some/path/and/filename.dot`.
+> **Note**
+> A `.dot` extension is always append to the you given.
+
+- After the DOT file is generated, you can convert it into a PNG image with Graphviz.
+```shell
+dot -Tpng nfa.dot -O
+```
+The PNG image will be located at `nfa.dot.png`.
+See the [command line documentation of Graphviz](https://graphviz.org/doc/info/command.html) to learn more.
 
 ## 🚀 Development <a name = "development"></a>
 There are several *make targets* to use.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Match mode:
 
 Written by: Lai-YT
 
-regexp version: 0.0.1
+regexp version: 0.1.0
 ```
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ $ make tests
 $ make valgrind
 ```
 
+- Run the command line tests
+```shell
+# Give permission on execution
+$ chmod +x cli_test.sh
+
+# Run CLI tests
+$ ./cli_test.sh
+```
+
 ## 🎈 Usage <a name="usage"></a>
 Get the help message,
 ```shell

--- a/cli_test.sh
+++ b/cli_test.sh
@@ -37,6 +37,7 @@ echo_in_yellow "${TITILE_BANNER} Running CLI tests..."
 pass_count=0
 fail_count=0
 if make clean >/dev/null 2>&1 && make >/dev/null 2>&1; then
+    # begin test cases
     echo_in_yellow "${RUN_BANNER} Normal matched"
     args="(a|b)*abb ababb"
     echo "${BODY_BANNER} ${EXEC} ${args}"
@@ -131,6 +132,28 @@ if make clean >/dev/null 2>&1 && make >/dev/null 2>&1; then
     echo "${BODY_BANNER} tear-down: Removing ${DESIGNSTED}.${DOT_EXT}..."
     rm -f "${DESIGNSTED}.${DOT_EXT}"
 
+    echo_in_yellow "${RUN_BANNER} Output specified without using graph mode"
+    args="(a|b)*abb ababb -o file"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
+    if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "${FAILED_BANNER} should exit 1"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "${OK_BANNER}"
+        pass_count=$((pass_count + 1))
+    fi
+
+    echo_in_yellow "${RUN_BANNER} Output option set without file specified"
+    args="(a|b)*abb ababb -o"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
+    if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "${FAILED_BANNER} should exit 1"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "${OK_BANNER}"
+        pass_count=$((pass_count + 1))
+    fi
+    # tail of test cases
     echo_in_yellow "${SECTION_BANNER} $((pass_count + fail_count)) tests ran."
 else
     echo_in_red "${FAILED_BANNER} Compilation error"

--- a/cli_test.sh
+++ b/cli_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env sh
+
+NO_COLOR='\033[0m'
+
+echo_in_green() {
+    GREEN='\033[0;32m'
+    echo "${GREEN}$*${NO_COLOR}"
+}
+
+echo_in_red() {
+    RED='\033[0;31m'
+    echo "${RED}$*${NO_COLOR}"
+}
+
+echo_in_yellow() {
+    YELLOW='\033[0;33m'
+    echo "${YELLOW}$*${NO_COLOR}"
+}
+
+EXEC=bin/regexp
+echo_in_yellow "[==========] Running CLI tests..."
+pass_count=0
+fail_count=0
+if make clean >/dev/null 2>&1 && make >/dev/null 2>&1; then
+    echo_in_yellow "[ RUN      ] Normal matched"
+    args="(a|b)*abb ababb"
+    echo "[          ] ${EXEC} ${args}"
+    if ! echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "[  FAILED  ] should exit 0"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "[       OK ]"
+        pass_count=$((pass_count + 1))
+    fi
+
+    echo_in_yellow "[ RUN      ] Normal unmatched"
+    args="(a|b)*abb abab"
+    echo "[          ] ${EXEC} ${args}"
+    if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "[  FAILED  ] should exit 1"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "[       OK ]"
+        pass_count=$((pass_count + 1))
+    fi
+
+    echo_in_yellow "[ RUN      ] Ill-formed regex"
+    args="(a|b*abb ababb"
+    echo "[          ] ${EXEC} ${args}"
+    if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "[  FAILED  ] should exit 1"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "[       OK ]"
+        pass_count=$((pass_count + 1))
+    fi
+
+    echo_in_yellow "[ RUN      ] Missing string"
+    args="(a|b)*abb"
+    echo "[          ] ${EXEC} ${args}"
+    if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "[  FAILED  ] should exit 1"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "[       OK ]"
+        pass_count=$((pass_count + 1))
+    fi
+
+    echo_in_yellow "[ RUN      ] Unknown argument"
+    args="(a|b)*abb ababb unknown"
+    echo "[          ] ${EXEC} ${args}"
+    if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "[  FAILED  ] should exit 1"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "[       OK ]"
+        pass_count=$((pass_count + 1))
+    fi
+
+    DOT_EXT="dot"
+    echo_in_yellow "[ RUN      ] Graph NFA to default file"
+    DEFAULT="nfa"
+    echo "[          ] set-up: Removing ${DEFAULT}.${DOT_EXT}..."
+    rm -f "${DEFAULT}.${DOT_EXT}"
+    args="-g (a|b)*abb"
+    echo "[          ] ${EXEC} ${args}"
+    if ! echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "[  FAILED  ] should exit 0"
+        fail_count=$((fail_count + 1))
+    elif [ ! -f "${DEFAULT}.${DOT_EXT}" ]; then
+        echo_in_red "[  FAILED  ] output file ${DEFAULT}.${DOT_EXT} not found"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "[       OK ]"
+        pass_count=$((pass_count + 1))
+    fi
+    echo "[          ] tear-down: Removing ${DEFAULT}.${DOT_EXT}..."
+    rm -f "${DEFAULT}.${DOT_EXT}"
+
+    echo_in_yellow "[ RUN      ] Graph NFA to designated file"
+    DESIGNSTED="cli_test_nfa"
+    echo "[          ] set-up: Removing ${DESIGNSTED}.${DOT_EXT}..."
+    rm -f "${DESIGNSTED}.${DOT_EXT}"
+    args="-g (a|b)*abb -o ${DESIGNSTED}"
+    echo "[          ] ${EXEC} ${args}"
+    if ! echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "[  FAILED  ] should exit 0"
+        fail_count=$((fail_count + 1))
+    elif [ ! -f "${DESIGNSTED}.${DOT_EXT}" ]; then
+        echo_in_red "[  FAILED  ] output file ${DESIGNSTED}.${DOT_EXT} not found"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "[       OK ]"
+        pass_count=$((pass_count + 1))
+    fi
+    echo "[          ] tear-down: Removing ${DESIGNSTED}.${DOT_EXT}..."
+    rm -f "${DESIGNSTED}.${DOT_EXT}"
+
+    echo_in_yellow "[----------] $((pass_count + fail_count)) tests ran."
+else
+    echo_in_red "[  FAILED  ] Compilation error"
+    exit 1
+fi
+
+echo ""
+echo_in_yellow "[==========] Summary"
+if [ $pass_count -ne 0 ]; then
+    echo_in_green "[  PASSED  ] ${pass_count} tests."
+fi
+if [ $fail_count -ne 0 ]; then
+    echo_in_red "[  FAILED  ] ${fail_count} tests."
+    exit 1
+fi
+exit 0

--- a/cli_test.sh
+++ b/cli_test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env sh
 
+#
+# Exit 0 if all tests passed, otherwise 1.
+# If you get any code other them these two, an unexpected error may have occured.
+#
+
 NO_COLOR='\033[0m'
 
 echo_in_green() {
@@ -17,118 +22,131 @@ echo_in_yellow() {
     echo "${YELLOW}$*${NO_COLOR}"
 }
 
+TITILE_BANNER="[==========]"
+RUN_BANNER="[ RUN      ]"
+BODY_BANNER="[          ]"
+OK_BANNER="[       OK ]"
+FAILED_BANNER="[  FAILED  ]"
+SECTION_BANNER="[----------]"
+
+#
+# To add a new test, extend the following test case list
+#
 EXEC=bin/regexp
-echo_in_yellow "[==========] Running CLI tests..."
+echo_in_yellow "${TITILE_BANNER} Running CLI tests..."
 pass_count=0
 fail_count=0
 if make clean >/dev/null 2>&1 && make >/dev/null 2>&1; then
-    echo_in_yellow "[ RUN      ] Normal matched"
+    echo_in_yellow "${RUN_BANNER} Normal matched"
     args="(a|b)*abb ababb"
-    echo "[          ] ${EXEC} ${args}"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
     if ! echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
-        echo_in_red "[  FAILED  ] should exit 0"
+        echo_in_red "${FAILED_BANNER} should exit 0"
         fail_count=$((fail_count + 1))
     else
-        echo_in_green "[       OK ]"
+        echo_in_green "${OK_BANNER}"
         pass_count=$((pass_count + 1))
     fi
 
-    echo_in_yellow "[ RUN      ] Normal unmatched"
+    echo_in_yellow "${RUN_BANNER} Normal unmatched"
     args="(a|b)*abb abab"
-    echo "[          ] ${EXEC} ${args}"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
     if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
-        echo_in_red "[  FAILED  ] should exit 1"
+        echo_in_red "${FAILED_BANNER} should exit 1"
         fail_count=$((fail_count + 1))
     else
-        echo_in_green "[       OK ]"
+        echo_in_green "${OK_BANNER}"
         pass_count=$((pass_count + 1))
     fi
 
-    echo_in_yellow "[ RUN      ] Ill-formed regex"
+    echo_in_yellow "${RUN_BANNER} Ill-formed regex"
     args="(a|b*abb ababb"
-    echo "[          ] ${EXEC} ${args}"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
     if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
-        echo_in_red "[  FAILED  ] should exit 1"
+        echo_in_red "${FAILED_BANNER} should exit 1"
         fail_count=$((fail_count + 1))
     else
-        echo_in_green "[       OK ]"
+        echo_in_green "${OK_BANNER}"
         pass_count=$((pass_count + 1))
     fi
 
-    echo_in_yellow "[ RUN      ] Missing string"
+    echo_in_yellow "${RUN_BANNER} Missing string"
     args="(a|b)*abb"
-    echo "[          ] ${EXEC} ${args}"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
     if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
-        echo_in_red "[  FAILED  ] should exit 1"
+        echo_in_red "${FAILED_BANNER} should exit 1"
         fail_count=$((fail_count + 1))
     else
-        echo_in_green "[       OK ]"
+        echo_in_green "${OK_BANNER}"
         pass_count=$((pass_count + 1))
     fi
 
-    echo_in_yellow "[ RUN      ] Unknown argument"
+    echo_in_yellow "${RUN_BANNER} Unknown argument"
     args="(a|b)*abb ababb unknown"
-    echo "[          ] ${EXEC} ${args}"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
     if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
-        echo_in_red "[  FAILED  ] should exit 1"
+        echo_in_red "${FAILED_BANNER} should exit 1"
         fail_count=$((fail_count + 1))
     else
-        echo_in_green "[       OK ]"
+        echo_in_green "${OK_BANNER}"
         pass_count=$((pass_count + 1))
     fi
 
     DOT_EXT="dot"
-    echo_in_yellow "[ RUN      ] Graph NFA to default file"
+    echo_in_yellow "${RUN_BANNER} Graph NFA to default file"
     DEFAULT="nfa"
-    echo "[          ] set-up: Removing ${DEFAULT}.${DOT_EXT}..."
+    echo "${BODY_BANNER} set-up: Removing ${DEFAULT}.${DOT_EXT}..."
     rm -f "${DEFAULT}.${DOT_EXT}"
     args="-g (a|b)*abb"
-    echo "[          ] ${EXEC} ${args}"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
     if ! echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
-        echo_in_red "[  FAILED  ] should exit 0"
+        echo_in_red "${FAILED_BANNER} should exit 0"
         fail_count=$((fail_count + 1))
     elif [ ! -f "${DEFAULT}.${DOT_EXT}" ]; then
-        echo_in_red "[  FAILED  ] output file ${DEFAULT}.${DOT_EXT} not found"
+        echo_in_red "${FAILED_BANNER} output file ${DEFAULT}.${DOT_EXT} not found"
         fail_count=$((fail_count + 1))
     else
-        echo_in_green "[       OK ]"
+        echo_in_green "${OK_BANNER}"
         pass_count=$((pass_count + 1))
     fi
-    echo "[          ] tear-down: Removing ${DEFAULT}.${DOT_EXT}..."
+    echo "${BODY_BANNER} tear-down: Removing ${DEFAULT}.${DOT_EXT}..."
     rm -f "${DEFAULT}.${DOT_EXT}"
 
-    echo_in_yellow "[ RUN      ] Graph NFA to designated file"
+    echo_in_yellow "${RUN_BANNER} Graph NFA to designated file"
     DESIGNSTED="cli_test_nfa"
-    echo "[          ] set-up: Removing ${DESIGNSTED}.${DOT_EXT}..."
+    echo "${BODY_BANNER} set-up: Removing ${DESIGNSTED}.${DOT_EXT}..."
     rm -f "${DESIGNSTED}.${DOT_EXT}"
     args="-g (a|b)*abb -o ${DESIGNSTED}"
-    echo "[          ] ${EXEC} ${args}"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
     if ! echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
-        echo_in_red "[  FAILED  ] should exit 0"
+        echo_in_red "${FAILED_BANNER} should exit 0"
         fail_count=$((fail_count + 1))
     elif [ ! -f "${DESIGNSTED}.${DOT_EXT}" ]; then
-        echo_in_red "[  FAILED  ] output file ${DESIGNSTED}.${DOT_EXT} not found"
+        echo_in_red "${FAILED_BANNER} output file ${DESIGNSTED}.${DOT_EXT} not found"
         fail_count=$((fail_count + 1))
     else
-        echo_in_green "[       OK ]"
+        echo_in_green "${OK_BANNER}"
         pass_count=$((pass_count + 1))
     fi
-    echo "[          ] tear-down: Removing ${DESIGNSTED}.${DOT_EXT}..."
+    echo "${BODY_BANNER} tear-down: Removing ${DESIGNSTED}.${DOT_EXT}..."
     rm -f "${DESIGNSTED}.${DOT_EXT}"
 
-    echo_in_yellow "[----------] $((pass_count + fail_count)) tests ran."
+    echo_in_yellow "${SECTION_BANNER} $((pass_count + fail_count)) tests ran."
 else
-    echo_in_red "[  FAILED  ] Compilation error"
+    echo_in_red "${FAILED_BANNER} Compilation error"
     exit 1
 fi
 
+TITILE_BANNER="[==========]"
+FAILED_BANNER="[  FAILED  ]"
+PASSED_BANNER="[  PASSED  ]"
 echo ""
-echo_in_yellow "[==========] Summary"
+echo_in_yellow "${TITILE_BANNER} Summary"
 if [ $pass_count -ne 0 ]; then
-    echo_in_green "[  PASSED  ] ${pass_count} tests."
+    echo_in_green "${PASSED_BANNER} ${pass_count} tests."
 fi
 if [ $fail_count -ne 0 ]; then
-    echo_in_red "[  FAILED  ] ${fail_count} tests."
+    echo_in_red "${FAILED_BANNER} ${fail_count} tests."
     exit 1
 fi
 exit 0

--- a/src/args.h
+++ b/src/args.h
@@ -25,6 +25,8 @@
 struct options {
   bool help;
   bool version;
+  bool graph;
+  char filename[BUF_SIZE];
   char regexp[BUF_SIZE];
   char string[BUF_SIZE];
 };

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@
 #include "args.h"
 #include "colors.h"
 #include "regexp.h"
+#include "visstate.h"
 
 int main(int argc, char* argv[]) {
   /* Read command line options */
@@ -36,12 +37,20 @@ int main(int argc, char* argv[]) {
 
   const char* post = re2post(options.regexp);
   if (!post) {
-    fprintf(stderr, RED "The regexp \"%s\" is ill-formed or too long.\n" NO_COLOR,
+    fprintf(stderr,
+            RED "The regexp \"%s\" is ill-formed or too long.\n" NO_COLOR,
             options.regexp);
     exit(EXIT_FAILURE);
   }
 
   Nfa* nfa = post2nfa(post);
+  {
+    FILE* graph = fopen("nfa.dot", "w");
+    nfa2dot(nfa, graph);
+    fclose(graph);
+    graph = NULL;
+  }
+
   bool matches_the_string = is_accepted(nfa, options.string);
   if (matches_the_string) {
 #ifdef DEBUG

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,8 @@ int main(int argc, char* argv[]) {
   fprintf(stdout, CYAN "Command line options:\n" NO_COLOR);
   fprintf(stdout, CYAN "  help: %d\n" NO_COLOR, options.help);
   fprintf(stdout, CYAN "  version: %d\n" NO_COLOR, options.version);
+  fprintf(stdout, CYAN "  graph: %d\n" NO_COLOR, options.graph);
+  fprintf(stdout, CYAN "  filename: %s\n" NO_COLOR, options.filename);
   fprintf(stdout, CYAN "  regexp: %s\n" NO_COLOR, options.regexp);
   fprintf(stdout, CYAN "  string: %s\n" NO_COLOR, options.string);
 #endif
@@ -44,11 +46,21 @@ int main(int argc, char* argv[]) {
   }
 
   Nfa* nfa = post2nfa(post);
-  {
-    FILE* graph = fopen("nfa.dot", "w");
-    nfa2dot(nfa, graph);
-    fclose(graph);
-    graph = NULL;
+  if (options.graph) {
+    char filename[BUF_SIZE + 4];
+    snprintf(filename, BUF_SIZE + 4, "%s.dot", options.filename);
+    FILE* dotfile = fopen(filename, "w");
+    if (!dotfile) {
+      fprintf(stderr, RED "Can't open file: \"%s\"\n" NO_COLOR, filename);
+      exit(EXIT_FAILURE);
+    }
+    nfa2dot(nfa, dotfile);
+#ifdef DEBUG
+    fprintf(stdout, YELLOW "Dot file written to \"%s\"\n" NO_COLOR, filename);
+#endif
+    fclose(dotfile);
+    delete_nfa(nfa);
+    return EXIT_SUCCESS;
   }
 
   bool matches_the_string = is_accepted(nfa, options.string);

--- a/src/messages.c
+++ b/src/messages.c
@@ -57,20 +57,20 @@ void description() {
 }
 
 void graph_mode() {
-  fprintf(stdout, WHITE
-          "Graph mode:\n"
-          "  Converts the regular expression into a graph,\n"
-          "  exits with 1 if regexp is ill-formed or the file can't be opened\n"
-          "\n"
-          "  -d, --graph             Converts the NFA of the regexp into a "
-          "Graphviz\n"
-          "                        dot file (default: False)\n"
-          "  -o FILE, --output FILE\n"
-          "                        The name of the dot file.\n"
-          "                        A .dot extension is appended automatically\n"
-          "                        (default: nfa)\n"
-          "  regexp                The regular expression to be converted\n"
-          "\n" NO_COLOR);
+  fprintf(
+      stdout, WHITE
+      "Graph mode:\n"
+      "  Converts the regular expression into a graph,\n"
+      "  exits with 1 if regexp is ill-formed or the file can't be opened\n"
+      "\n"
+      "  -d, --graph           Converts the NFA of the regexp into a Graphviz\n"
+      "                        dot file (default: False)\n"
+      "  -o FILE, --output FILE\n"
+      "                        The name of the dot file.\n"
+      "                        A .dot extension is appended automatically\n"
+      "                        (default: nfa)\n"
+      "  regexp                The regular expression to be converted\n"
+      "\n" NO_COLOR);
 }
 
 void match_mode() {

--- a/src/messages.c
+++ b/src/messages.c
@@ -24,7 +24,7 @@
  * Help message
  */
 void help() {
-  fprintf(stdout, BLUE __PROGRAM_NAME__ "\n\n" NO_COLOR);
+  fprintf(stdout, CYAN __PROGRAM_NAME__ "\n\n" NO_COLOR);
   usage();
   description();
   options();
@@ -37,7 +37,8 @@ void help() {
  */
 void usage() {
   fprintf(stdout, YELLOW "Usage: " NO_COLOR);
-  fprintf(stdout, "%s [options] [regexp string]\n\n", __PROGRAM_NAME__);
+  fprintf(stdout, "%s [-h] [-V] [-d regexp [-o FILE]] [regexp string]\n\n",
+          __PROGRAM_NAME__);
 }
 
 /*
@@ -50,20 +51,52 @@ void description() {
           "Supports only ( | ) * + ?. No escapes.\n"
           "Compiles to NFA and then simulates NFA using Thompson's algorithm.\n"
           "\n"
-          "Matches the string (string) to the regular expression (regexp) and "
-          "exits with 1 if it does not match.\n\n");
+          "One can either graph the regexp or match a string.\n"
+          "See the following options.\n"
+          "\n");
+}
+
+void graph_mode() {
+  fprintf(stdout, WHITE
+          "Graph mode:\n"
+          "  Converts the regular expression into a graph,\n"
+          "  exits with 1 if regexp is ill-formed or the file can't be opened\n"
+          "\n"
+          "  -d, --graph             Converts the NFA of the regexp into a "
+          "Graphviz\n"
+          "                        dot file (default: False)\n"
+          "  -o FILE, --output FILE\n"
+          "                        The name of the dot file.\n"
+          "                        A .dot extension is appended automatically\n"
+          "                        (default: nfa)\n"
+          "  regexp                The regular expression to be converted\n"
+          "\n" NO_COLOR);
+}
+
+void match_mode() {
+  fprintf(stdout, WHITE
+          "Match mode:\n"
+          "  Matches the string with the regular expression,\n"
+          "  exits with 1 if regexp is ill-formed or it does not match\n"
+          "\n"
+          "  regexp                The regular expression to use on matching\n"
+          "  string                The string to be matched\n"
+          "\n" NO_COLOR);
 }
 
 /*
  * Options message
  */
 void options() {
-  fprintf(stdout, YELLOW "Options:\n\n" NO_COLOR);
   fprintf(stdout,
-          WHITE "\t-v, --version\n" NO_COLOR "\t\tPrints %s version\n\n",
+          WHITE
+          "Options:\n"
+          "  -h, --help            Shows this help message and exit\n"
+          "  -V, --version         Shows %s version and exit\n"
+          "\n" NO_COLOR,
           __PROGRAM_NAME__);
-  fprintf(stdout,
-          WHITE "\t-h, --help\n" NO_COLOR "\t\tPrints this help message\n\n");
+  graph_mode();
+  match_mode();
 }
 
 /*

--- a/src/messages.h
+++ b/src/messages.h
@@ -18,7 +18,7 @@
 #define MESSAGES_H
 
 #define __PROGRAM_NAME__ "regexp"
-#define __PROGRAM_VERSION__ "0.0.1"
+#define __PROGRAM_VERSION__ "0.1.0"
 #define __PROGRAM_AUTHOR__ "Lai-YT"
 
 void help();

--- a/src/visstate.c
+++ b/src/visstate.c
@@ -23,13 +23,13 @@ static State* pop(List** stack) {
 static void state2dot(State* state, FILE* f) {
   for (size_t i = 0; i < num_of_outs(state->label); i++) {
     fprintf(f, "\t%d -> %d", state->id, state->outs[i]->id);
-    fputs(" [label = ", f);
+    fputs(" [label = \"", f);
     if (state->label > CHAR_MAX) {
       fputs("eps", f);  // epsilon, avoid unicode
     } else {
       fputc(state->label, f);
     }
-    fputs("]\n", f);
+    fputs("\"]\n", f);
   }
 }
 
@@ -54,7 +54,8 @@ static void states2dot(State* start, FILE* f) {
 void nfa2dot(const Nfa* nfa, FILE* f) {
   fputs("strict digraph nfa {\n", f);
   fputs("\trankdir=LR;\n", f);
-  fprintf(f, "\tnode [shape = doublecircle]; %d;", nfa->accept->id);
+  fputs("\tnode [fixedsize=true];\n", f);
+  fprintf(f, "\tnode [shape = doublecircle]; %d;\n", nfa->accept->id);
   fputs("\tnode [shape = circle];\n", f);
   states2dot(nfa->start, f);
   fputs("}\n", f);

--- a/src/visstate.c
+++ b/src/visstate.c
@@ -20,6 +20,8 @@ static State* pop(List** stack) {
   return top;
 }
 
+/// @details The label of an epsilon transition is "eps", others are the
+/// characters they take.
 static void state2dot(State* state, FILE* f) {
   for (size_t i = 0; i < num_of_outs(state->label); i++) {
     fprintf(f, "\t%d -> %d", state->id, state->outs[i]->id);
@@ -51,6 +53,9 @@ static void states2dot(State* start, FILE* f) {
   }
 }
 
+/// @details A strict digraph that goes from left to right. The accepting state
+/// is represented as a double circle, others are circles. Every states have the
+/// same node size.
 void nfa2dot(const Nfa* nfa, FILE* f) {
   fputs("strict digraph nfa {\n", f);
   fputs("\trankdir=LR;\n", f);

--- a/src/visstate.c
+++ b/src/visstate.c
@@ -1,0 +1,61 @@
+#include <limits.h>
+#include <stdio.h>
+
+#include "list.h"
+#include "map.h"
+#include "post2nfa.h"
+
+static void push(List** stack, State* s) {
+  List* tmp = create_list((s));
+  append_list(tmp, *stack);
+  *stack = tmp;
+}
+
+static State* pop(List** stack) {
+  State* top = (*stack)->val;
+  List* top_list = *stack;
+  *stack = (*stack)->next;
+  top_list->next = NULL;
+  delete_list(top_list);
+  return top;
+}
+
+static void state2dot(State* state, FILE* f) {
+  for (size_t i = 0; i < num_of_outs(state->label); i++) {
+    fprintf(f, "\t%d -> %d", state->id, state->outs[i]->id);
+    fputs(" [label = ", f);
+    if (state->label > CHAR_MAX) {
+      fputs("eps", f);  // epsilon, avoid unicode
+    } else {
+      fputc(state->label, f);
+    }
+    fputs("]\n", f);
+  }
+}
+
+static void states2dot(State* start, FILE* f) {
+  Map* converted = create_map();
+  List* to_convert = NULL;
+  push(&to_convert, start);
+  while (to_convert) {  // depth-first traversal
+    State* s = pop(&to_convert);
+    if (get_value(converted, s->id) /* is converted */
+        || s->label == ACCEPT /* has no transition */) {
+      continue;
+    }
+    state2dot(s, f);
+    insert_pair(converted, s->id, s);  // mark as converted
+    for (size_t i = 0; i < num_of_outs(s->label); i++) {
+      push(&to_convert, s->outs[i]);
+    }
+  }
+}
+
+void nfa2dot(const Nfa* nfa, FILE* f) {
+  fputs("strict digraph nfa {\n", f);
+  fputs("\trankdir=LR;\n", f);
+  fprintf(f, "\tnode [shape = doublecircle]; %d;", nfa->accept->id);
+  fputs("\tnode [shape = circle];\n", f);
+  states2dot(nfa->start, f);
+  fputs("}\n", f);
+}

--- a/src/visstate.h
+++ b/src/visstate.h
@@ -1,0 +1,12 @@
+#ifndef VISSTATE_H
+#define VISSTATE_H
+
+#include <stdio.h>
+
+#include "post2nfa.h"
+
+/// @brief Converts the states in nfa into a Graphviz dot file
+/// and writes into stream f.
+void nfa2dot(const Nfa* nfa, FILE* f);
+
+#endif /* end of include guard: VISSTATE_H */


### PR DESCRIPTION
# Motivation

*regexp* converts the regular expression into an NFA before simulating.
We would like to see what such NFA looks like, which is valuable in learning how Thompson's algorithm works.

This feature bumps the version to `0.2.0`.

# What's new?

- A `nfa2dot` function that traverses the NFA and does the conversion
- Command line options `--graph` (`-g`) and `--output` (`-o`) on using the graph mode and specifying the output *dot* file

# Breaking change

- The short option for getting the version number is now `-V` instead of `-v`. `-v` is preserved for the possible use of verbose. 

# How has this been tested?

A test script `cli_test.sh` feeds arguments the *regexp* and checks the exit code.
```shell
# Give permission on execution
$ chmod +x cli_test.sh

# Run CLI tests
$ ./cli_test.sh
```
# Checklist
I have completed the following:

- [x] Added appropriate comments to my code where the code is not easily understood.
- [x] Updated the relevant documentation.
- [x] Added tests to cover the proposed changes (and if not, explain why).

Resolves: #1 