### PR TITLE
Separate release and debug build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ _regexp_ uses [GNU Make](https://www.gnu.org/software/make/) to control the gene
 # Get the repo
 $ git clone https://github.com/Lai-YT/regexp.git
 
-# Compile to executable
-$ make
+# Compile to executable with optimizations
+$ make release
 ```
 
 The executable will be located in the `bin/` folder and named `regexp`.
@@ -55,14 +55,13 @@ $ make tests
 ```shell
 $ make valgrind
 ```
-
 - Run the command line tests
 ```shell
 # Give permission on execution
 $ chmod +x cli_test.sh
 
-# Run CLI tests
-$ ./cli_test.sh
+# Run CLI tests on release (or debug) build
+$ ./cli_test.sh --release # --debug
 ```
 
 ## 🎈 Usage <a name="usage"></a>
@@ -156,14 +155,21 @@ dot -Tpng nfa.dot -o nfa.png
 See the [command line documentation of Graphviz](https://graphviz.org/doc/info/command.html) to learn more.
 
 ## 🚀 Development <a name = "development"></a>
-There are several *make targets* to use.
+Run _regex_ with debug messages and less optimizations (`-O0`).
+```shell
+make debug
+```
+
+There are several other *make targets* to use.
 ```shell
 $ make help
 ```
 
 ```
 Target rules:
-    all      - Compiles and generates binary file
+    debug    - Compiles and generates binary file with
+               debug messages and less optimizations
+    release  - Compiles and generates optimized binary file
     tests    - Compiles with cmocka and runs test binary file
     valgrind - Runs test binary file using valgrind tool
     fmt      - Formats the source and test files

--- a/cli_test.sh
+++ b/cli_test.sh
@@ -1,9 +1,35 @@
 #!/usr/bin/env sh
 
-#
-# Exit 0 if all tests passed, otherwise 1.
-# If you get any code other them these two, an unexpected error may have occured.
-#
+usage() {
+    echo "usage: ${0} build"
+    echo ""
+    echo "  Exit 0 if all tests passed, otherwise 1."
+    echo "  If you get any code other them these two,"
+    echo "  an unexpected error may have occured."
+    echo ""
+    echo "build:"
+    echo "  Specify one of the builds to test on."
+    echo ""
+    echo "  -d, --debug"
+    echo "  -r, --release"
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+    exit 1
+fi
+
+case "$1" in
+    -d|--debug)
+        BUILD_MODE='debug'
+        ;;
+    -r|--release)
+        BUILD_MODE='release'
+        ;;
+    *)
+        usage
+        exit 1
+esac
 
 NO_COLOR='\033[0m'
 
@@ -33,10 +59,10 @@ SECTION_BANNER="[----------]"
 # To add a new test, extend the following test case list
 #
 EXEC=bin/regexp
-echo_in_yellow "${TITILE_BANNER} Running CLI tests..."
+echo_in_yellow "${TITILE_BANNER} Running CLI tests on ${BUILD_MODE} build..."
 pass_count=0
 fail_count=0
-if make clean >/dev/null 2>&1 && make >/dev/null 2>&1; then
+if make clean >/dev/null 2>&1 && make ${BUILD_MODE} >/dev/null 2>&1; then
     # begin test cases
     echo_in_yellow "${RUN_BANNER} Normal matched"
     args="(a|b)*abb ababb"


### PR DESCRIPTION
# Motivation

Developers like to have *regexp* be built with a symbol table and less optimization, so tools such as *Valgrind* and *GDB* produce messages properly, and have `DEBUG` defined for messages and assertions.
On the other hand, users like the tool to be fast and have no unnecessary messages.

# What's new?

- New targets `debug` and `release` are added to the `Makefile`,
with flags `-O0 -g3 -DDEBUG=1` and `-O3`, respectively
- Target `all` removed from `Makefile`. The behavior of `make` with the default target is kept the same
- Command line options `-debug` (`-d`) and `--release` (`-r`) are added to `cli_test.sh` for running CLI tests on different builds

# Breaking change

- `make all` is no longer available

# How has this been tested?

For the new options on `cli_test.sh`,
- run with (1) an unknown option and (2) a wrong number of options, the usage message should show
- run with (1) `--debug` and (2) `--release` with `>/dev/null &>$1` removed, debug messages should show and not show, respectively

# Checklist
I have completed the following:

- [x] Added appropriate comments to my code where the code is not easily understood.
- [x] Updated the relevant documentation.
- [x] Added tests to cover the proposed changes (and if not, explain why).
