### PR TITLE
Cache NFA states to build DFA on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ bin/regexp -h # or --help
 ```
 regexp
 
-Usage: regexp [-h] [-V] [-d regexp [-o FILE]] [regexp string]
+Usage: regexp [-h] [-V] [-d regexp [-o FILE]] [[-c] regexp string]
 
 Description: Regular expression implementation.
 Supports only ( | ) * + ?. No escapes.
@@ -103,12 +103,13 @@ Match mode:
   Matches the string with the regular expression,
   exits with 1 if regexp is ill-formed or it does not match
 
+  -c, --cache           Caches NFA states to build DFA on the fly
   regexp                The regular expression to use on matching
   string                The string to be matched
 
 Written by: Lai-YT
 
-regexp version: 0.1.0
+regexp version: 0.2.0
 ```
 
 ### Example
@@ -124,6 +125,15 @@ This exits with 0 if the string is matched by the regular expression or 1 if the
 You can check the exit code with the following command if you're on an Unix shell.
 ```shell
 $ echo $?
+```
+
+#### Caching the NFA to build a DFA on the fly
+"In a sense, Thompson's NFA simulation is executing the equivalent DFA by reconstructing each DFA state as it is needed. Rather than throw away this work after each step, we could cache them, avoiding the cost of repeating the computation in the future and essentially computing the equivalent DFA as it is needed." (Russ Cox, see [Acknowledgments](#acknowledgement))
+
+_regexp_ doesn't cache the states by default. \
+Set the `--cache` (or `-c`) option to enable the caching.
+```shell
+$ bin/regexp -c '(a|b)*abb' 'bababb'
 ```
 
 #### Graph mode

--- a/cli_test.sh
+++ b/cli_test.sh
@@ -75,8 +75,30 @@ if make clean >/dev/null 2>&1 && make ${BUILD_MODE} >/dev/null 2>&1; then
         pass_count=$((pass_count + 1))
     fi
 
+    echo_in_yellow "${RUN_BANNER} Normal matched (cache)"
+    args="-c (a|b)*abb ababb"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
+    if ! echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "${FAILED_BANNER} should exit 0"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "${OK_BANNER}"
+        pass_count=$((pass_count + 1))
+    fi
+
     echo_in_yellow "${RUN_BANNER} Normal unmatched"
     args="(a|b)*abb abab"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
+    if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "${FAILED_BANNER} should exit 1"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "${OK_BANNER}"
+        pass_count=$((pass_count + 1))
+    fi
+
+    echo_in_yellow "${RUN_BANNER} Normal unmatched (cache)"
+    args="-c (a|b)*abb abab"
     echo "${BODY_BANNER} ${EXEC} ${args}"
     if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
         echo_in_red "${FAILED_BANNER} should exit 1"
@@ -171,6 +193,17 @@ if make clean >/dev/null 2>&1 && make ${BUILD_MODE} >/dev/null 2>&1; then
 
     echo_in_yellow "${RUN_BANNER} Output option set without file specified"
     args="(a|b)*abb ababb -o"
+    echo "${BODY_BANNER} ${EXEC} ${args}"
+    if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
+        echo_in_red "${FAILED_BANNER} should exit 1"
+        fail_count=$((fail_count + 1))
+    else
+        echo_in_green "${OK_BANNER}"
+        pass_count=$((pass_count + 1))
+    fi
+
+    echo_in_yellow "${RUN_BANNER} Cache option set under graph mode"
+    args="(a|b)*abb ababb -g -c"
     echo "${BODY_BANNER} ${EXEC} ${args}"
     if echo "${args}" | xargs ${EXEC} >/dev/null 2>&1; then
         echo_in_red "${FAILED_BANNER} should exit 1"

--- a/src/args.c
+++ b/src/args.c
@@ -24,6 +24,7 @@ https://opensource.org/license/mit/.
 static void set_default_options(options_t* options) {
   options->help = false;
   options->version = false;
+  options->cache = false;
   options->graph = false;
   strncpy(options->filename, "nfa", BUF_SIZE);
 }
@@ -42,6 +43,10 @@ void switch_options(int arg, options_t* options) {
       options->version = true;
       version();
       exit(EXIT_SUCCESS);
+
+    case 'c':
+      options->cache = true;
+      break;
 
     case 'g':
       options->graph = true;
@@ -95,16 +100,14 @@ void options_parser(int argc, char* argv[], options_t* options) {
 
   /* getopt allowed options */
   static struct option long_options[] = {
-      {"help", no_argument, 0, 'h'},
-      {"version", no_argument, 0, 'V'},
-      {"graph", no_argument, 0, 'g'},
-      {"output", required_argument, 0, 'o'},
-      {0, 0, 0, 0},
+      {"help", no_argument, 0, 'h'},         {"version", no_argument, 0, 'V'},
+      {"cache", no_argument, 0, 'c'},        {"graph", no_argument, 0, 'g'},
+      {"output", required_argument, 0, 'o'}, {0, 0, 0, 0},
   };
 
   while (true) {
     int option_index = 0;
-    arg = getopt_long(argc, argv, "hVgo:", long_options, &option_index);
+    arg = getopt_long(argc, argv, "hVcgo:", long_options, &option_index);
 
     /* End of the options? */
     if (arg == -1) {

--- a/src/args.h
+++ b/src/args.h
@@ -18,6 +18,7 @@ https://opensource.org/license/mit/.
 struct options {
   bool help;
   bool version;
+  bool cache;
   bool graph;
   char filename[BUF_SIZE];
   char regexp[BUF_SIZE];

--- a/src/cache.c
+++ b/src/cache.c
@@ -1,8 +1,10 @@
 #include "cache.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "map.h"
+#include "regexp.h"  // get_next_states
 
 static int state_id = 0;
 
@@ -19,4 +21,49 @@ DfaState* create_dfa_state(Map* states) {
 void delete_dfa_state(DfaState* dstate) {
   delete_map(dstate->states);
   free(dstate);
+}
+
+void cache_dstate(Map* cache_table, DfaState* dstate) {
+  insert_pair(cache_table, dstate->id, dstate);
+}
+
+/// @details Worst case time complexity O(n^2 * m).
+/// m is the capacity of the map, which is the cost of iterating over a map; n
+/// is the size of the map, each search has worst case O(n). Another n for
+/// checking every key.
+static bool map_equal(Map* m1, Map* m2) {
+  if (get_size(m1) != get_size(m2)) {
+    return false;
+  }
+  MapIterator* itr = create_map_iterator(m1);
+  while (has_next(itr)) {
+    to_next(itr);
+    if (!get_value(m2, get_current_key(itr))) {
+      delete_map_iterator(itr);
+      return false;
+    }
+  }
+  delete_map_iterator(itr);
+  return true;
+}
+
+bool has_cache(Map* cache_table, DfaState* curr_dstate, char c) {
+  if (curr_dstate->next[(int)c] != NO_CACHE) {
+    return true;
+  }
+  bool has_cache = false;
+  Map* next_states = get_next_states(curr_dstate->states, c);
+  MapIterator* itr = create_map_iterator(cache_table);
+  while (has_next(itr)) {
+    to_next(itr);
+    DfaState* dstate = get_current_value(itr);
+    if (map_equal(next_states, dstate->states)) {
+      curr_dstate->next[(int)c] = dstate->id;
+      has_cache = true;
+      break;
+    }
+  }
+  delete_map_iterator(itr);
+  delete_map(next_states);
+  return has_cache;
 }

--- a/src/cache.c
+++ b/src/cache.c
@@ -11,12 +11,12 @@ DfaState* create_dfa_state(Map* states) {
   state->id = state_id++;
   state->states = states;
   for (int i = 0; i < 128; i++) {
-    state->next[i] = -1;
+    state->next[i] = NO_CACHE;
   }
   return state;
 }
 
-void delete_dfa_state(DfaState* root) {
-  delete_map(root->states);
-  free(root);
+void delete_dfa_state(DfaState* dstate) {
+  delete_map(dstate->states);
+  free(dstate);
 }

--- a/src/cache.c
+++ b/src/cache.c
@@ -10,7 +10,7 @@ DfaState* create_dfa_state(Map* states) {
   DfaState* state = malloc(sizeof(DfaState));
   state->id = state_id++;
   state->states = states;
-  for (int i = 0; i < 256; i++) {
+  for (int i = 0; i < 128; i++) {
     state->next[i] = -1;
   }
   return state;

--- a/src/cache.c
+++ b/src/cache.c
@@ -35,15 +35,12 @@ static bool map_equal(Map* m1, Map* m2) {
   if (get_size(m1) != get_size(m2)) {
     return false;
   }
-  MapIterator* itr = create_map_iterator(m1);
-  while (has_next(itr)) {
-    to_next(itr);
+  FOR_EACH_ITR(m1, itr, {
     if (!get_value(m2, get_current_key(itr))) {
       delete_map_iterator(itr);
       return false;
     }
-  }
-  delete_map_iterator(itr);
+  });
   return true;
 }
 
@@ -53,17 +50,14 @@ bool has_cache(Map* cache_table, DfaState* curr_dstate, char c) {
   }
   bool has_cache = false;
   Map* next_states = get_next_states(curr_dstate->states, c);
-  MapIterator* itr = create_map_iterator(cache_table);
-  while (has_next(itr)) {
-    to_next(itr);
+  FOR_EACH_ITR(cache_table, itr, {
     DfaState* dstate = get_current_value(itr);
     if (map_equal(next_states, dstate->states)) {
       curr_dstate->next[(int)c] = dstate->id;
       has_cache = true;
       break;
     }
-  }
-  delete_map_iterator(itr);
+  });
   delete_map(next_states);
   return has_cache;
 }

--- a/src/cache.c
+++ b/src/cache.c
@@ -1,0 +1,22 @@
+#include "cache.h"
+
+#include <stdlib.h>
+
+#include "map.h"
+
+static int state_id = 0;
+
+DfaState* create_dfa_state(Map* states) {
+  DfaState* state = malloc(sizeof(DfaState));
+  state->id = state_id++;
+  state->states = states;
+  for (int i = 0; i < 256; i++) {
+    state->next[i] = -1;
+  }
+  return state;
+}
+
+void delete_dfa_state(DfaState* root) {
+  delete_map(root->states);
+  free(root);
+}

--- a/src/cache.h
+++ b/src/cache.h
@@ -3,10 +3,12 @@
 
 #include "map.h"
 
+/// @brief A DfaState is a set of NFA state with possible transitions on 128
+/// ASCII characters.
 typedef struct DfaState {
   int id;
   Map* states;
-  int next[256];  // -1 if there's no transition on such character
+  int next[128];  // -1 if there's no transition on such character
 } DfaState;
 
 DfaState* create_dfa_state(Map* states);

--- a/src/cache.h
+++ b/src/cache.h
@@ -22,4 +22,12 @@ DfaState* create_dfa_state(Map* states);
 /// @note Does not delete the next DFA states.
 void delete_dfa_state(DfaState*);
 
+/// @brief Stores the DFA state to the cache_table.
+void cache_dstate(Map* cache_table, DfaState* dstate);
+
+/// @note This function has side effect on modifing the next states of
+/// curr_dstate on label c, which happens if the next states has a
+/// corresponding DFA state on the cache table.
+bool has_cache(Map* cache_table, DfaState* curr_dstate, char c);
+
 #endif

--- a/src/cache.h
+++ b/src/cache.h
@@ -3,15 +3,23 @@
 
 #include "map.h"
 
+static const int NO_CACHE = -1;
+
 /// @brief A DfaState is a set of NFA state with possible transitions on 128
 /// ASCII characters.
 typedef struct DfaState {
   int id;
   Map* states;
-  int next[128];  // -1 if there's no transition on such character
+  /// @brief The id of the next DFA state on input character; -1 if is not yet
+  /// cached.
+  int next[128];
 } DfaState;
 
+/// @param states The NFA states in this DFA state.
+/// @note The ownership of the states is taken by the DFA state.
 DfaState* create_dfa_state(Map* states);
-void delete_dfa_state(DfaState* root);
+
+/// @note Does not delete the next DFA states.
+void delete_dfa_state(DfaState*);
 
 #endif

--- a/src/cache.h
+++ b/src/cache.h
@@ -1,0 +1,15 @@
+#ifndef CACHE_H
+#define CACHE_H
+
+#include "map.h"
+
+typedef struct DfaState {
+  int id;
+  Map* states;
+  int next[256];  // -1 if there's no transition on such character
+} DfaState;
+
+DfaState* create_dfa_state(Map* states);
+void delete_dfa_state(DfaState* root);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,7 @@ int main(int argc, char* argv[]) {
   fprintf(stdout, CYAN "Command line options:\n" NO_COLOR);
   fprintf(stdout, CYAN "  help: %d\n" NO_COLOR, options.help);
   fprintf(stdout, CYAN "  version: %d\n" NO_COLOR, options.version);
+  fprintf(stdout, CYAN "  cache: %d\n" NO_COLOR, options.cache);
   fprintf(stdout, CYAN "  graph: %d\n" NO_COLOR, options.graph);
   fprintf(stdout, CYAN "  filename: %s\n" NO_COLOR, options.filename);
   fprintf(stdout, CYAN "  regexp: %s\n" NO_COLOR, options.regexp);
@@ -57,7 +58,9 @@ int main(int argc, char* argv[]) {
     return EXIT_SUCCESS;
   }
 
-  bool matches_the_string = is_accepted(nfa, options.string);
+  bool matches_the_string = options.cache
+                                ? is_accepted_with_cache(nfa, options.string)
+                                : is_accepted(nfa, options.string);
   if (matches_the_string) {
 #ifdef DEBUG
     fprintf(stdout, YELLOW "The regexp matches the string.\n" NO_COLOR);

--- a/src/map.h
+++ b/src/map.h
@@ -52,4 +52,26 @@ bool has_next(MapIterator*);
 /// @exception Assertion error if there's no more to_next.
 void to_next(MapIterator*);
 
+/// @brief Iterates over the map with an iterator and executes the statement
+/// for each iteration.
+/// @param map The map to iterate over.
+/// @param itr_name The name of the iterator to be created by this macro, which
+/// can be used within the statement to refer to the current value or key.
+/// @param statement The statement to execute in every iteration.If there are
+/// multiple statements, they should be enclosed in curly brackets. The
+/// statement can use the `continue` and `break` keywords to control the
+/// iteration, and the `return` keyword to exit the function that calls this
+/// macro.
+/// @note This macro creates an iterator object internally and deletes it after
+/// the iteration is complete.
+#define FOR_EACH_ITR(map, itr_name, statement)        \
+  {                                                   \
+    MapIterator* itr_name = create_map_iterator(map); \
+    while (has_next(itr_name)) {                      \
+      to_next(itr_name);                              \
+      statement;                                      \
+    }                                                 \
+    delete_map_iterator(itr_name);                    \
+  }
+
 #endif /* end of include guard: MAP_H */

--- a/src/messages.c
+++ b/src/messages.c
@@ -30,7 +30,7 @@ void help() {
  */
 void usage() {
   fprintf(stdout, YELLOW "Usage: " NO_COLOR);
-  fprintf(stdout, "%s [-h] [-V] [-d regexp [-o FILE]] [regexp string]\n\n",
+  fprintf(stdout, "%s [-h] [-V] [-d regexp [-o FILE]] [[-c] regexp string]\n\n",
           __PROGRAM_NAME__);
 }
 
@@ -72,6 +72,7 @@ void match_mode() {
           "  Matches the string with the regular expression,\n"
           "  exits with 1 if regexp is ill-formed or it does not match\n"
           "\n"
+          "  -c, --cache           Caches NFA states to build DFA on the fly\n"
           "  regexp                The regular expression to use on matching\n"
           "  string                The string to be matched\n"
           "\n" NO_COLOR);

--- a/src/messages.h
+++ b/src/messages.h
@@ -11,7 +11,7 @@ https://opensource.org/license/mit/.
 #define MESSAGES_H
 
 #define __PROGRAM_NAME__ "regexp"
-#define __PROGRAM_VERSION__ "0.1.0"
+#define __PROGRAM_VERSION__ "0.2.0"
 #define __PROGRAM_AUTHOR__ "Lai-YT"
 
 void help();

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -33,14 +33,7 @@ static void collect_reachable_states(Map* states, State* start) {
 static void delete_reachable_states(State* s) {
   Map* states_to_delete = create_map();
   collect_reachable_states(states_to_delete, s);
-
-  MapIterator* itr = create_map_iterator(states_to_delete);
-  while (has_next(itr)) {
-    to_next(itr);
-    delete_state(get_current_value(itr));
-  }
-  delete_map_iterator(itr);
-
+  FOR_EACH_ITR(states_to_delete, itr, delete_state(get_current_value(itr)));
   delete_map(states_to_delete);
 }
 

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -9,101 +9,22 @@
 #include "re2post.h"
 #include "stack.h"
 
-/// @return The states reachable from the current states on label c with epsilon
-/// moves.
-Map* get_next_states(Map* current_states, char c);
-
-/// @details Worst case time complexity O(n^2 * m).
-/// m is the capacity of the map, which is the cost of iterating over a map; n
-/// is the size of the map, each search has worst case O(n). Another n for
-/// checking every key.
-bool map_equal(Map* m1, Map* m2);
-
-/// @brief Caching the ids of the DFA states.
-static Map* cache_table = NULL;
-
-/// @brief Stores the DFA state to the cache_table.
-void cache_dstate(DfaState* dstate);
-
-/// @note This function has side effect on modifing the next states of
-/// curr_dstate on label c, which happens if the next states has a
-/// corresponding DFA state on the cache table.
-bool has_cache(DfaState* curr_dstate, char c);
-
-/// @brief Stores the DFA state to the cache_table.
-void cache_dstate(DfaState* dstate) {
-  insert_pair(cache_table, dstate->id, dstate);
-}
-
-/// @note This function has side effect on modifing the next states of
-/// curr_dstate on character c, which happens if the next states has a
-/// corresponding DFA state on the cache table.
-bool has_cache(DfaState* curr_dstate, char c) {
-  if (curr_dstate->next[(int)c] != NO_CACHE) {
-    return true;
-  }
-  bool has_cache = false;
-  Map* next_states = get_next_states(curr_dstate->states, c);
-  MapIterator* itr = create_map_iterator(cache_table);
-  while (has_next(itr)) {
-    to_next(itr);
-    DfaState* dstate = get_current_value(itr);
-    if (map_equal(next_states, dstate->states)) {
-      curr_dstate->next[(int)c] = dstate->id;
-      has_cache = true;
-      break;
-    }
-  }
-  delete_map_iterator(itr);
-  delete_map(next_states);
-  return has_cache;
-}
-
-Map* get_next_states(Map* current_states, char c) {
-  Map* moves = move(current_states, c);
-  Map* next_states = epsilon_closure(moves);
-  delete_map(moves);
-  return next_states;
-}
-
 /// @return The epsilon closure from start.
-static Map* get_start_states(State* start) {
-  Map* start_states = create_map();
-  insert_pair(start_states, start->id, start);
-  Map* tmp = epsilon_closure(start_states);
-  delete_map(start_states);
-  start_states = tmp;
-  return start_states;
-}
-
-bool map_equal(Map* m1, Map* m2) {
-  if (get_size(m1) != get_size(m2)) {
-    return false;
-  }
-  MapIterator* itr = create_map_iterator(m1);
-  while (has_next(itr)) {
-    to_next(itr);
-    if (!get_value(m2, get_current_key(itr))) {
-      delete_map_iterator(itr);
-      return false;
-    }
-  }
-  delete_map_iterator(itr);
-  return true;
-}
+static Map* get_start_states(State* start);
 
 /// @details Simulates the NFA by moving between the possible set of states.
 /// If the accepting state is in the set after the last input character is
 /// consumed, the NFA accepts the string.
 bool is_accepted(const Nfa* nfa, const char* s) {
-  cache_table = create_map();
+  /// @brief Caching the ids of the DFA states.
+  Map* cache_table = create_map();
   DfaState* curr_dstate = create_dfa_state(get_start_states(nfa->start));
-  cache_dstate(curr_dstate);
+  cache_dstate(cache_table, curr_dstate);
   for (; *s; s++) {
-    if (!has_cache(curr_dstate, *s)) {
+    if (!has_cache(cache_table, curr_dstate, *s)) {
       DfaState* next_dstate
           = create_dfa_state(get_next_states(curr_dstate->states, *s));
-      cache_dstate(next_dstate);
+      cache_dstate(cache_table, next_dstate);
       curr_dstate->next[(int)*s] = next_dstate->id;
     }
     curr_dstate = get_value(cache_table, curr_dstate->next[(int)*s]);
@@ -169,4 +90,20 @@ Map* move(Map* from, char c) {
   }
   delete_map_iterator(itr);
   return outs;
+}
+
+static Map* get_start_states(State* start) {
+  Map* start_states = create_map();
+  insert_pair(start_states, start->id, start);
+  Map* tmp = epsilon_closure(start_states);
+  delete_map(start_states);
+  start_states = tmp;
+  return start_states;
+}
+
+Map* get_next_states(Map* current_states, char c) {
+  Map* moves = move(current_states, c);
+  Map* next_states = epsilon_closure(moves);
+  delete_map(moves);
+  return next_states;
 }

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -9,11 +9,74 @@
 #include "re2post.h"
 #include "stack.h"
 
+/// @return The states reachable from the current states on label c with epsilon
+/// moves.
+Map* get_next_states(Map* current_states, char c);
+
 /// @details Worst case time complexity O(n^2 * m).
 /// m is the capacity of the map, which is the cost of iterating over a map; n
 /// is the size of the map, each search has worst case O(n). Another n for
 /// checking every key.
-bool map_cmp(Map* m1, Map* m2) {
+bool map_equal(Map* m1, Map* m2);
+
+/// @brief Caching the ids of the DFA states.
+static Map* cache_table = NULL;
+
+/// @brief Stores the DFA state to the cache_table.
+void cache_dstate(DfaState* dstate);
+
+/// @note This function has side effect on modifing the next states of
+/// curr_dstate on label c, which happens if the next states has a
+/// corresponding DFA state on the cache table.
+bool has_cache(DfaState* curr_dstate, char c);
+
+/// @brief Stores the DFA state to the cache_table.
+void cache_dstate(DfaState* dstate) {
+  insert_pair(cache_table, dstate->id, dstate);
+}
+
+/// @note This function has side effect on modifing the next states of
+/// curr_dstate on character c, which happens if the next states has a
+/// corresponding DFA state on the cache table.
+bool has_cache(DfaState* curr_dstate, char c) {
+  if (curr_dstate->next[(int)c] != NO_CACHE) {
+    return true;
+  }
+  bool has_cache = false;
+  Map* next_states = get_next_states(curr_dstate->states, c);
+  MapIterator* itr = create_map_iterator(cache_table);
+  while (has_next(itr)) {
+    to_next(itr);
+    DfaState* dstate = get_current_value(itr);
+    if (map_equal(next_states, dstate->states)) {
+      curr_dstate->next[(int)c] = dstate->id;
+      has_cache = true;
+      break;
+    }
+  }
+  delete_map_iterator(itr);
+  delete_map(next_states);
+  return has_cache;
+}
+
+Map* get_next_states(Map* current_states, char c) {
+  Map* moves = move(current_states, c);
+  Map* next_states = epsilon_closure(moves);
+  delete_map(moves);
+  return next_states;
+}
+
+/// @return The epsilon closure from start.
+static Map* get_start_states(State* start) {
+  Map* start_states = create_map();
+  insert_pair(start_states, start->id, start);
+  Map* tmp = epsilon_closure(start_states);
+  delete_map(start_states);
+  start_states = tmp;
+  return start_states;
+}
+
+bool map_equal(Map* m1, Map* m2) {
   if (get_size(m1) != get_size(m2)) {
     return false;
   }
@@ -33,38 +96,17 @@ bool map_cmp(Map* m1, Map* m2) {
 /// If the accepting state is in the set after the last input character is
 /// consumed, the NFA accepts the string.
 bool is_accepted(const Nfa* nfa, const char* s) {
-  Map* start = create_map();
-  insert_pair(start, nfa->start->id, nfa->start);
-  Map* states = epsilon_closure(start);
-  delete_map(start);
-  Map* dstates = create_map();
-  DfaState* dstate = create_dfa_state(states);
-  insert_pair(dstates, dstate->id, dstate);
+  cache_table = create_map();
+  DfaState* curr_dstate = create_dfa_state(get_start_states(nfa->start));
+  cache_dstate(curr_dstate);
   for (; *s; s++) {
-    if (dstate->next[(int)*s] == -1) {
-      bool has_cache = false;
-      Map* moves = move(dstate->states, *s);
-      states = epsilon_closure(moves);
-      delete_map(moves);
-      MapIterator* itr = create_map_iterator(dstates);
-      while (has_next(itr)) {
-        to_next(itr);
-        if (map_cmp(states, ((DfaState*)get_current_value(itr))->states)) {
-          dstate->next[(int)*s] = get_current_key(itr);
-          delete_map(states);
-          states = NULL;
-          has_cache = true;
-          break;
-        }
-      }
-      delete_map_iterator(itr);
-      if (!has_cache) {
-        DfaState* next_dstate = create_dfa_state(states);
-        insert_pair(dstates, next_dstate->id, next_dstate);
-        dstate->next[(int)*s] = next_dstate->id;
-      }
+    if (!has_cache(curr_dstate, *s)) {
+      DfaState* next_dstate
+          = create_dfa_state(get_next_states(curr_dstate->states, *s));
+      cache_dstate(next_dstate);
+      curr_dstate->next[(int)*s] = next_dstate->id;
     }
-    dstate = get_value(dstates, dstate->next[(int)*s]);
+    curr_dstate = get_value(cache_table, curr_dstate->next[(int)*s]);
   }
 
   /// Thompson's algorithm proves that: For any regular language L, there is an
@@ -72,14 +114,17 @@ bool is_accepted(const Nfa* nfa, const char* s) {
   /// distinct from the starting state s.
   /// See
   /// https://courses.engr.illinois.edu/cs374/fa2018/notes/models/04-nfa.pdf.
-  const bool accepted = get_value(dstate->states, nfa->accept->id);
-  MapIterator* itr = create_map_iterator(dstates);
+  const bool accepted = get_value(curr_dstate->states, nfa->accept->id);
+
+  // traverse the cache table to delete all the DFA states
+  MapIterator* itr = create_map_iterator(cache_table);
   while (has_next(itr)) {
     to_next(itr);
     delete_dfa_state(get_current_value(itr));
   }
   delete_map_iterator(itr);
-  delete_map(dstates);
+  delete_map(cache_table);
+
   return accepted;
 }
 

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -12,40 +12,54 @@
 /// @return The epsilon closure from start.
 static Map* get_start_states(State* start);
 
+static bool cache_on_the_fly = true;
+
 /// @details Simulates the NFA by moving between the possible set of states.
 /// If the accepting state is in the set after the last input character is
 /// consumed, the NFA accepts the string.
 bool is_accepted(const Nfa* nfa, const char* s) {
-  /// @brief Caching the ids of the DFA states.
-  Map* cache_table = create_map();
-  DfaState* curr_dstate = create_dfa_state(get_start_states(nfa->start));
-  cache_dstate(cache_table, curr_dstate);
-  for (; *s; s++) {
-    if (!has_cache(cache_table, curr_dstate, *s)) {
-      DfaState* next_dstate
-          = create_dfa_state(get_next_states(curr_dstate->states, *s));
-      cache_dstate(cache_table, next_dstate);
-      curr_dstate->next[(int)*s] = next_dstate->id;
+  if (cache_on_the_fly) {
+    /// @brief Caching the ids of the DFA states.
+    Map* cache_table = create_map();
+    DfaState* curr_dstate = create_dfa_state(get_start_states(nfa->start));
+    cache_dstate(cache_table, curr_dstate);
+    for (; *s; s++) {
+      if (!has_cache(cache_table, curr_dstate, *s)) {
+        DfaState* next_dstate
+            = create_dfa_state(get_next_states(curr_dstate->states, *s));
+        cache_dstate(cache_table, next_dstate);
+        curr_dstate->next[(int)*s] = next_dstate->id;
+      }
+      curr_dstate = get_value(cache_table, curr_dstate->next[(int)*s]);
     }
-    curr_dstate = get_value(cache_table, curr_dstate->next[(int)*s]);
+
+    const bool accepted = get_value(curr_dstate->states, nfa->accept->id);
+
+    // traverse the cache table to delete all the DFA states
+    MapIterator* itr = create_map_iterator(cache_table);
+    while (has_next(itr)) {
+      to_next(itr);
+      delete_dfa_state(get_current_value(itr));
+    }
+    delete_map_iterator(itr);
+    delete_map(cache_table);
+
+    return accepted;
+  }
+  Map* states = get_start_states(nfa->start);
+  for (; *s; s++) {
+    Map* next_states = get_next_states(states, *s);
+    delete_map(states);
+    states = next_states;
   }
 
-  /// Thompson's algorithm proves that: For any regular language L, there is an
-  /// NFA that accepts L that has exactly one accepting state t, which is
+  /// Thompson's algorithm proves that: For any regular language L, there is
+  /// an NFA that accepts L that has exactly one accepting state t, which is
   /// distinct from the starting state s.
   /// See
   /// https://courses.engr.illinois.edu/cs374/fa2018/notes/models/04-nfa.pdf.
-  const bool accepted = get_value(curr_dstate->states, nfa->accept->id);
-
-  // traverse the cache table to delete all the DFA states
-  MapIterator* itr = create_map_iterator(cache_table);
-  while (has_next(itr)) {
-    to_next(itr);
-    delete_dfa_state(get_current_value(itr));
-  }
-  delete_map_iterator(itr);
-  delete_map(cache_table);
-
+  const bool accepted = get_value(states, nfa->accept->id);
+  delete_map(states);
   return accepted;
 }
 

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -36,12 +36,7 @@ bool is_accepted(const Nfa* nfa, const char* s) {
     const bool accepted = get_value(curr_dstate->states, nfa->accept->id);
 
     // traverse the cache table to delete all the DFA states
-    MapIterator* itr = create_map_iterator(cache_table);
-    while (has_next(itr)) {
-      to_next(itr);
-      delete_dfa_state(get_current_value(itr));
-    }
-    delete_map_iterator(itr);
+    FOR_EACH_ITR(cache_table, itr, delete_dfa_state(get_current_value(itr)));
     delete_map(cache_table);
 
     return accepted;
@@ -68,15 +63,10 @@ Map* epsilon_closure(Map* start) {
 
   Map* closure = create_map();
   // Inserts all of the start states into the closure and mark as to reach out.
-  {  // limit the scope of itr
-    MapIterator* itr = create_map_iterator(start);
-    while (has_next(itr)) {
-      to_next(itr);
-      push_stack(to_reach_out, get_current_value(itr));
-      insert_pair(closure, get_current_key(itr), get_current_value(itr));
-    }
-    delete_map_iterator(itr);
-  }
+  FOR_EACH_ITR(start, itr, {
+    push_stack(to_reach_out, get_current_value(itr));
+    insert_pair(closure, get_current_key(itr), get_current_value(itr));
+  });
 
   while (!is_empty_stack(to_reach_out)) {
     State* top = pop_stack(to_reach_out);
@@ -94,15 +84,12 @@ Map* epsilon_closure(Map* start) {
 
 Map* move(Map* from, char c) {
   Map* outs = create_map();
-  MapIterator* itr = create_map_iterator(from);
-  while (has_next(itr)) {
-    to_next(itr);
+  FOR_EACH_ITR(from, itr, {
     State* s = get_current_value(itr);
     if (s->label == c) {
       insert_pair(outs, s->outs[0]->id, s->outs[0]);
     }
-  }
-  delete_map_iterator(itr);
+  });
   return outs;
 }
 

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -3,33 +3,11 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "cache.h"
 #include "map.h"
 #include "post2nfa.h"
 #include "re2post.h"
 #include "stack.h"
-
-static int state_id = 0;
-
-typedef struct DfaState {
-  int id;
-  Map* states;
-  int next[256];
-} DfaState;
-
-DfaState* create_dfa_state(Map* states) {
-  DfaState* state = malloc(sizeof(DfaState));
-  state->id = state_id++;
-  state->states = states;
-  for (int i = 0; i < 256; i++) {
-    state->next[i] = -1;
-  }
-  return state;
-}
-
-void delete_dfa_state(DfaState* root) {
-  delete_map(root->states);
-  free(root);
-}
 
 /// @details Worst case time complexity O(n^2 * m).
 /// m is the capacity of the map, which is the cost of iterating over a map; n

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -10,11 +10,11 @@
 /// @details Simulates the NFA.
 bool is_accepted(const Nfa*, const char*);
 
-/// @brief Returns the states that are reachable from start with only epsilon
+/// @return The states that are reachable from start with only epsilon
 /// transitions, including all of the start states itself.
 Map* epsilon_closure(Map* start);
 
-/// @brief Returns the states that are reachable from the map of states on label
+/// @return The states that are reachable from the map of states on label
 /// c with non-epsilon moves.
 Map* move(Map*, char c);
 

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -10,6 +10,10 @@
 /// @details Simulates the NFA.
 bool is_accepted(const Nfa*, const char*);
 
+/// @return Whether the string is accepted by the NFA.
+/// @note Caches the states to build a DFA on the fly.
+bool is_accepted_with_cache(const Nfa* nfa, const char* s);
+
 /// @return The states that are reachable from start with only epsilon
 /// transitions, including all of the start states itself.
 Map* epsilon_closure(Map* start);

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -18,4 +18,8 @@ Map* epsilon_closure(Map* start);
 /// c with non-epsilon moves.
 Map* move(Map*, char c);
 
+/// @return The states reachable from the current states on label c with epsilon
+/// moves.
+Map* get_next_states(Map* current_states, char c);
+
 #endif /* end of include guard: REGEXP_H */

--- a/test/main.c
+++ b/test/main.c
@@ -54,6 +54,8 @@ int main(void) {
       cmocka_unit_test(test_move_null),
       cmocka_unit_test(test_is_accepted),
       cmocka_unit_test(test_all_regexp),
+      cmocka_unit_test(test_is_accepted_with_cache),
+      cmocka_unit_test(test_all_regexp_with_cache),
       // map.h
       cmocka_unit_test(test_map_insert_and_search),
       cmocka_unit_test(test_map_delete),

--- a/test/regexp.h
+++ b/test/regexp.h
@@ -152,6 +152,18 @@ static void test_is_accepted() {
   delete_nfa(nfa);
 }
 
+static void test_is_accepted_with_cache() {
+  // a -> b -> accept
+  State* accept = create_state(ACCEPT, NULL);
+  State* b = create_state('b', &accept);
+  State* a = create_state('a', &b);
+  Nfa* nfa = create_nfa(a, accept);
+
+  assert_true(is_accepted_with_cache(nfa, "ab"));
+
+  delete_nfa(nfa);
+}
+
 static void test_all_regexp() {
   const char* re = "(a|b)*abb";  // consists only a/b and ends with abb
 
@@ -164,6 +176,22 @@ static void test_all_regexp() {
   assert_true(is_accepted(nfa, "abaabbaabb"));
   assert_false(is_accepted(nfa, "abaabbbb"));
   assert_false(is_accepted(nfa, "abaabbab"));
+
+  delete_nfa(nfa);
+}
+
+static void test_all_regexp_with_cache() {
+  const char* re = "(a|b)*abb";  // consists only a/b and ends with abb
+
+  const char* post = re2post(re);
+  Nfa* nfa = post2nfa(post);
+
+  assert_true(is_accepted_with_cache(nfa, "abb"));
+  assert_true(is_accepted_with_cache(nfa, "babb"));
+  assert_true(is_accepted_with_cache(nfa, "bbbbabb"));
+  assert_true(is_accepted_with_cache(nfa, "abaabbaabb"));
+  assert_false(is_accepted_with_cache(nfa, "abaabbbb"));
+  assert_false(is_accepted_with_cache(nfa, "abaabbab"));
 
   delete_nfa(nfa);
 }


### PR DESCRIPTION
# Motivation

DFAs are more efficient to execute than NFAs because DFAs are only ever in one state at a time.

This feature bumps the version to `0.2.0`.

# What's new?

- New function `is_accepted_with_cache`. It's the caching version of `is_accepted`, which caches the states while simulating the NFA
- Command line option `--cache` (`-c`) to use the caching version under *match mode*

# How has this been tested?

- Unit tests on testing the matching with caching enabled
```shell
$ make tests
```
- CLI tests on testing the command line behavior & constraint (should not be specified under *graph mode*)
```shell
$ ./cli_test.sh
```

# Checklist

I have completed the following:

- [x] Added appropriate comments to my code where the code is not easily understood.
- [x] Updated the relevant documentation.
- [x] Added tests to cover the proposed changes (and if not, explain why).
