### PR TITLE
Check naming conventions & bug-proneness with Clang-Tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,32 @@
+Checks: >
+  -*,
+  bugprone-*,
+  performance-*,
+  readability-braces-around-statements,
+  readability-function-size,
+  readability-identifier-naming,
+  readability-inconsistent-declaration-parameter-name,
+  readability-isolate-declaration,
+  readability-magic-numbers
+  readability-misleading-indentation,
+  readability-non-const-parameter,
+  readability-redundant-control-flow,
+  readability-redundant-declaration,
+  readability-redundant-preprocessor,
+  readability-simplify-boolean-expr,
+
+WarningsAsErrors: "*"
+
+CheckOptions:
+  - { key: readability-identifier-naming.StructCase, value: CamelCase }
+  - { key: readability-identifier-naming.EnumCase, value: CamelCase }
+  - { key: readability-identifier-naming.UnionCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypedefCase, value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case }
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE }
+  # Consts other than globals and enums are lower case.
+  - { key: readability-identifier-naming.EnumConstantCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.GlobalConstantCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.ConstantCase, value: lower_case }

--- a/Makefile
+++ b/Makefile
@@ -145,12 +145,17 @@ valgrind:
 	exit $${EXIT_CODE}
 
 
-# Rule for formatting the source code use clang-format
+# Rule for formatting the source code with clang-format
 fmt:
 	@clang-format -i \
 		-style=file \
 		{$(SRCDIR),$(TESTDIR)}/*.{h,c}
 
+# Rule for enforcing naming conventions and checking proneness to bugs with clang-tidy
+tidy:
+	@clang-tidy --quiet \
+		{$(SRCDIR),$(TESTDIR)}/*.{h,c} \
+		-- $(CFLAGS)
 
 # Compile tests and run the test binary
 tests: debug

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ help:
 	@echo "    tests    - Compiles with cmocka and runs test binary file"
 	@echo "    valgrind - Runs test binary file using valgrind tool"
 	@echo "    fmt      - Formats the source and test files"
+	@echo "    tidy     - Checks naming conventions and bug-proneness"
 	@echo "    clean    - Cleans the project by removing binaries"
 	@echo "    help     - Prints a help message with target rules"
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Target rules:
     tests    - Compiles with cmocka and runs test binary file
     valgrind - Runs test binary file using valgrind tool
     fmt      - Formats the source and test files
+    tidy     - Checks naming conventions and bug-proneness
     clean    - Cleans the project by removing binaries
     help     - Prints a help message with target rules
 ```
@@ -240,6 +241,14 @@ _regexp_ uses [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) as for
 Format source and test codes,
 ```shell
 $ make fmt
+```
+
+### Naming conventions & bug-proneness checking
+_regexp_ uses [Clang-Tidy](https://clang.llvm.org/extra/clang-tidy/) as the linter, which checks naming conventions and several bug-proneness.
+
+Check naming conventions and bug-proneness,
+```shell
+$ make tidy
 ```
 
 ## 🎉 Acknowledgements <a name = "acknowledgement"></a>

--- a/src/args.c
+++ b/src/args.c
@@ -21,7 +21,7 @@ https://opensource.org/license/mit/.
 /*
  * Sets the default options
  */
-static void set_default_options(options_t* options) {
+static void set_default_options(Options* options) {
   options->help = false;
   options->version = false;
   options->cache = false;
@@ -34,7 +34,7 @@ static void set_default_options(options_t* options) {
 /*
  * Finds the matching case of the current command line option
  */
-void switch_options(int arg, options_t* options) {
+void switch_options(int arg, Options* options) {
   switch (arg) {
     case 'h':
       options->help = true;
@@ -74,7 +74,7 @@ void switch_options(int arg, options_t* options) {
   }
 }
 
-void get_regexp(int argc, char* argv[], options_t* options) {
+void get_regexp(int argc, char* argv[], Options* options) {
   if (optind < argc) {
     strncpy(options->regexp, argv[optind++], BUF_SIZE);
   } else {
@@ -83,7 +83,7 @@ void get_regexp(int argc, char* argv[], options_t* options) {
   }
 }
 
-void get_string(int argc, char* argv[], options_t* options) {
+void get_string(int argc, char* argv[], Options* options) {
   if (optind < argc) {
     strncpy(options->string, argv[optind++], BUF_SIZE);
   } else {
@@ -95,7 +95,7 @@ void get_string(int argc, char* argv[], options_t* options) {
 /*
  * Public function that loops until command line options were parsed
  */
-void options_parser(int argc, char* argv[], options_t* options) {
+void options_parser(int argc, char* argv[], Options* options) {
   set_default_options(options);
 
   int arg; /* Current option */

--- a/src/args.h
+++ b/src/args.h
@@ -26,9 +26,9 @@ struct options {
 };
 
 /* Exports options as a global type */
-typedef struct options options_t;
+typedef struct options Options;
 
 /* Public functions section */
-void options_parser(int argc, char* argv[], options_t* options);
+void options_parser(int argc, char* argv[], Options* options);
 
 #endif  // ARGS_H

--- a/src/main.c
+++ b/src/main.c
@@ -61,15 +61,13 @@ int main(int argc, char* argv[]) {
   bool matches_the_string = options.cache
                                 ? is_accepted_with_cache(nfa, options.string)
                                 : is_accepted(nfa, options.string);
+#ifdef DEBUG
   if (matches_the_string) {
-#ifdef DEBUG
     fprintf(stdout, YELLOW "The regexp matches the string.\n" NO_COLOR);
-#endif
   } else {
-#ifdef DEBUG
     fprintf(stdout, RED "The regexp doesn't match the string.\n" NO_COLOR);
-#endif
   }
+#endif
   delete_nfa(nfa);
   return matches_the_string ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,7 @@ https://opensource.org/license/mit/.
 
 int main(int argc, char* argv[]) {
   /* Read command line options */
-  options_t options;
+  Options options;
   options_parser(argc, argv, &options);
 
 #ifdef DEBUG

--- a/src/map.c
+++ b/src/map.c
@@ -2,7 +2,7 @@
 
 #include <assert.h>
 #include <stdbool.h>
-#include <stddef.h>  // size_t
+#include <stddef.h>
 #include <stdlib.h>
 
 #include "prime.h"
@@ -13,8 +13,8 @@ typedef struct MapPair {
 } MapPair;
 
 struct Map {
-  size_t capacity;
-  size_t size;
+  int capacity;
+  int size;
   MapPair** pairs;
 };
 
@@ -35,12 +35,12 @@ static void delete_map_pair(MapPair* item) {
   free(item);
 }
 
-static Map* create_map_with_capacity(size_t capacity) {
+static Map* create_map_with_capacity(int capacity) {
   Map* map = malloc(sizeof(Map));
   map->capacity = capacity;
   map->size = 0;
   // initialize to NULL, which means unused
-  map->pairs = calloc(map->capacity, sizeof *map->pairs);
+  map->pairs = calloc(map->capacity, sizeof(MapPair));
   return map;
 }
 
@@ -49,7 +49,7 @@ Map* create_map() {
 }
 
 void delete_map(Map* map) {
-  for (size_t i = 0; i < map->capacity; i++) {
+  for (int i = 0; i < map->capacity; i++) {
     if (map->pairs[i]) {
       delete_map_pair(map->pairs[i]);
       map->pairs[i] = NULL;
@@ -75,7 +75,7 @@ static int hash2(int n, int prime) {
 /// @brief A double hashing function that hashes the key into [0, capacity).
 /// @note Hashing is a large topic. This hash function is easy but may not be
 /// good.
-static int get_hashed_key(int key, size_t capacity, int attempt) {
+static int get_hashed_key(int key, int capacity, int attempt) {
   // the capacity we used is already a prime number
   int prime_1 = capacity;
   // a smaller prime in comparison with prime_1
@@ -121,7 +121,7 @@ static bool is_low_load(Map* map) {
 /// @note If the capacity is lower than MAP_BASE_CAPACITY, MAP_BASE_CAPACITY is
 /// used; if the capacity is not a prime number, the greater closet prime number
 /// is used.
-static void resize_map(Map* old, size_t capacity);
+static void resize_map(Map* old, int capacity);
 
 /// @details Double up the capacity if the map is under high load after the
 /// insertion.
@@ -159,7 +159,7 @@ void delete_pair(Map* map, int key) {
   }
 }
 
-static void resize_map(Map* old, size_t capacity) {
+static void resize_map(Map* old, int capacity) {
   if (capacity < MAP_BASE_CAPACITY) {
     capacity = MAP_BASE_CAPACITY;
   }
@@ -171,7 +171,7 @@ static void resize_map(Map* old, size_t capacity) {
   Map* new = create_map_with_capacity(capacity);
 
   // 2. Insert the pairs of the old map into the new map
-  for (size_t i = 0; i < old->capacity; i++) {
+  for (int i = 0; i < old->capacity; i++) {
     MapPair* item = old->pairs[i];
     if (item && item != PAIR_DELETED_MARKER) {
       insert_pair(new, item->key, item->val);

--- a/src/map.c
+++ b/src/map.c
@@ -84,7 +84,7 @@ static int get_hashed_key(int key, size_t capacity, int attempt) {
   return (hash1(key, prime_1) + hash2(key, prime_2) * attempt) % capacity;
 }
 
-static MapPair* PAIR_DELETED_MARKER = NULL;
+static MapPair* const PAIR_DELETED_MARKER = NULL;
 
 /// @return Whether the key of the pair is "key".
 /// @note Not null-safe.

--- a/src/map.h
+++ b/src/map.h
@@ -25,7 +25,7 @@ void delete_map(Map*);
 /// @note The val may or may not be heap-allocated since the map does
 /// not take the ownership. If val is heap allocated, the caller has to free it
 /// manually.
-void insert_pair(Map* ht, int key, void* val);
+void insert_pair(Map*, int key, void* val);
 
 /// @return The val mapped by key; NULL if not exists.
 void* get_value(Map*, int key);
@@ -64,14 +64,14 @@ void to_next(MapIterator*);
 /// macro.
 /// @note This macro creates an iterator object internally and deletes it after
 /// the iteration is complete.
-#define FOR_EACH_ITR(map, itr_name, statement)        \
-  {                                                   \
-    MapIterator* itr_name = create_map_iterator(map); \
-    while (has_next(itr_name)) {                      \
-      to_next(itr_name);                              \
-      statement;                                      \
-    }                                                 \
-    delete_map_iterator(itr_name);                    \
+#define FOR_EACH_ITR(map, itr_name, statement)         \
+  {                                                    \
+    MapIterator*(itr_name) = create_map_iterator(map); \
+    while (has_next(itr_name)) {                       \
+      to_next(itr_name);                               \
+      statement;                                       \
+    }                                                  \
+    delete_map_iterator(itr_name);                     \
   }
 
 #endif /* end of include guard: MAP_H */

--- a/src/messages.c
+++ b/src/messages.c
@@ -17,7 +17,7 @@ https://opensource.org/license/mit/.
  * Help message
  */
 void help() {
-  fprintf(stdout, CYAN __PROGRAM_NAME__ "\n\n" NO_COLOR);
+  fprintf(stdout, CYAN PROGRAM_NAME "\n\n" NO_COLOR);
   usage();
   description();
   options();
@@ -31,7 +31,7 @@ void help() {
 void usage() {
   fprintf(stdout, YELLOW "Usage: " NO_COLOR);
   fprintf(stdout, "%s [-h] [-V] [-d regexp [-o FILE]] [[-c] regexp string]\n\n",
-          __PROGRAM_NAME__);
+          PROGRAM_NAME);
 }
 
 /*
@@ -90,7 +90,7 @@ void options() {
           "  -h, --help            Shows this help message and exit\n"
           "  -V, --version         Shows %s version and exit\n"
           "\n" NO_COLOR,
-          __PROGRAM_NAME__);
+          PROGRAM_NAME);
   graph_mode();
   match_mode();
 }
@@ -100,13 +100,13 @@ void options() {
  */
 void author() {
   fprintf(stdout, YELLOW "Written by: " WHITE "%s\n\n" NO_COLOR,
-          __PROGRAM_AUTHOR__);
+          PROGRAM_AUTHOR);
 }
 
 /*
  * Version message
  */
 void version() {
-  fprintf(stdout, __PROGRAM_NAME__ " version: " WHITE "%s\n" NO_COLOR,
-          __PROGRAM_VERSION__);
+  fprintf(stdout, PROGRAM_NAME " version: " WHITE "%s\n" NO_COLOR,
+          PROGRAM_VERSION);
 }

--- a/src/messages.h
+++ b/src/messages.h
@@ -11,7 +11,7 @@ https://opensource.org/license/mit/.
 #define MESSAGES_H
 
 #define PROGRAM_NAME "regexp"
-#define PROGRAM_VERSION "1.0.0"
+#define PROGRAM_VERSION "1.0.1"
 #define PROGRAM_AUTHOR "Lai-YT"
 
 void help();

--- a/src/messages.h
+++ b/src/messages.h
@@ -10,9 +10,9 @@ https://opensource.org/license/mit/.
 #ifndef MESSAGES_H
 #define MESSAGES_H
 
-#define __PROGRAM_NAME__ "regexp"
-#define __PROGRAM_VERSION__ "1.0.0"
-#define __PROGRAM_AUTHOR__ "Lai-YT"
+#define PROGRAM_NAME "regexp"
+#define PROGRAM_VERSION "1.0.0"
+#define PROGRAM_AUTHOR "Lai-YT"
 
 void help();
 void usage();

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -6,7 +6,11 @@
 #include "map.h"
 #include "state.h"
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 Nfa* create_nfa(State* start, State* accept) {
+  // reason: a struct should be used in the case that parameters are
+  // easily swappable, but this function is exactly a
+  // creation of struct.
   Nfa* n = malloc(sizeof(Nfa));
   n->start = start;
   n->accept = accept;

--- a/src/re2post.c
+++ b/src/re2post.c
@@ -71,12 +71,12 @@ char* re2post(const char* re) {
   Unit* curr_paren_unit = malloc(sizeof(Unit));
   init_unit(curr_paren_unit);
 
-#define FREE_HEAP_ALLOCATED_VARS()         \
-    free(curr_paren_unit);                 \
-    while (!is_empty_stack(paren_units)) { \
-      free((Unit*)pop_stack(paren_units)); \
-    }                                      \
-    delete_stack(paren_units);             \
+#define FREE_HEAP_ALLOCATED_VARS()       \
+  free(curr_paren_unit);                 \
+  while (!is_empty_stack(paren_units)) { \
+    free((Unit*)pop_stack(paren_units)); \
+  }                                      \
+  delete_stack(paren_units);
 
   for (; *re; re++) {
     switch (*re) {

--- a/src/state.c
+++ b/src/state.c
@@ -29,7 +29,7 @@ State* create_state(const int label, State** outs) {
   new_state->label = label;
   new_state->id = state_id++;
 
-  new_state->outs = malloc(sizeof *new_state->outs * num_of_outs(label));
+  new_state->outs = malloc(sizeof(State) * num_of_outs(label));
   if (label == ACCEPT) {
     new_state->outs[0] = NULL;
   } else {

--- a/test/map.h
+++ b/test/map.h
@@ -18,12 +18,12 @@ static void test_map_insert_and_search() {
   int keys[] = {9, 217, 100};
   int vals[] = {90, 2170, 1000};
 
-  for (size_t i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     insert_pair(map, keys[i], vals + i);
   }
 
   assert_int_equal(get_size(map), 3);
-  for (size_t i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     int* val = get_value(map, keys[i]);
     assert_non_null(val);
     assert_ptr_equal(val, vals + i);
@@ -38,7 +38,7 @@ void test_map_delete() {
   Map* map = create_map();
   int keys[] = {9, 100, 217};
   int vals[] = {90, 2170, 1000};
-  for (size_t i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     insert_pair(map, keys[i], vals + i);
   }
 
@@ -60,17 +60,17 @@ void test_map_capacity_should_grow() {
   };
   Map* map = create_map();
   int keys[NUM_OF_PAIRS];
-  for (size_t i = 0; i < NUM_OF_PAIRS; i++) {
+  for (int i = 0; i < NUM_OF_PAIRS; i++) {
     keys[i] = i;
   }
   int vals[NUM_OF_PAIRS];  // using the memory address, not initialized
 
-  for (size_t i = 0; i < NUM_OF_PAIRS; i++) {
+  for (int i = 0; i < NUM_OF_PAIRS; i++) {
     insert_pair(map, keys[i], vals + i);
   }
 
   assert_int_equal(get_size(map), NUM_OF_PAIRS);
-  for (size_t i = 0; i < NUM_OF_PAIRS; i++) {
+  for (int i = 0; i < NUM_OF_PAIRS; i++) {
     int* val = get_value(map, keys[i]);
     assert_non_null(val);
     assert_ptr_equal(vals + i, val);
@@ -84,7 +84,7 @@ static void test_map_iterator() {
   Map* map = create_map();
   int keys[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};  // as same as indices
   int vals[10];  // using the memory address, not initialized
-  for (size_t i = 0; i < 10; i++) {
+  for (int i = 0; i < 10; i++) {
     insert_pair(map, keys[i], vals + i);
   }
 

--- a/test/state.h
+++ b/test/state.h
@@ -26,7 +26,8 @@ static void test_create_labeled_state() {
 }
 
 static void test_create_epsilon_state() {
-  State out1, out2;  // ill-formed but doesn't matter
+  State out1;
+  State out2;  // ill-formed but doesn't matter
   State* outs[] = {&out1, &out2};
 
   State* epsilon_state = create_state(SPLIT, outs);


### PR DESCRIPTION
# Motivation

Following naming conventions reduces the effort needed to read and understand source code and enables code reviews to focus on issues more important than syntax and naming standards.
Additionally, static checks can detect potential bugs; the earlier we find them, the less they cost.

Some bug-proneness is fixed. Bump the version to `1.0.1`.

# What's new?

- A `.clang-tidy` file that specifies the conventions to enforce and the static checks to make
- New targe `tidy` is added to the `Makefile`, which invokes the Clang-Tidy check
- #12
- #13. Some implementation details are changed

# How has this been tested?

- Unit tests & tidy checks
```shell
$ make tests && make tidy
```

# Checklist

I have completed the following:

- [x] Added appropriate comments to my code where the code is not easily understood.
- [x] Updated the relevant documentation.
- [x] Added tests to cover the proposed changes (and if not, explain why).
