### PR TITLE
Fix bug-proneness

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -61,15 +61,13 @@ int main(int argc, char* argv[]) {
   bool matches_the_string = options.cache
                                 ? is_accepted_with_cache(nfa, options.string)
                                 : is_accepted(nfa, options.string);
+#ifdef DEBUG
   if (matches_the_string) {
-#ifdef DEBUG
     fprintf(stdout, YELLOW "The regexp matches the string.\n" NO_COLOR);
-#endif
   } else {
-#ifdef DEBUG
     fprintf(stdout, RED "The regexp doesn't match the string.\n" NO_COLOR);
-#endif
   }
+#endif
   delete_nfa(nfa);
   return matches_the_string ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/map.c
+++ b/src/map.c
@@ -2,7 +2,7 @@
 
 #include <assert.h>
 #include <stdbool.h>
-#include <stddef.h>  // size_t
+#include <stddef.h>
 #include <stdlib.h>
 
 #include "prime.h"
@@ -13,8 +13,8 @@ typedef struct MapPair {
 } MapPair;
 
 struct Map {
-  size_t capacity;
-  size_t size;
+  int capacity;
+  int size;
   MapPair** pairs;
 };
 
@@ -35,12 +35,12 @@ static void delete_map_pair(MapPair* item) {
   free(item);
 }
 
-static Map* create_map_with_capacity(size_t capacity) {
+static Map* create_map_with_capacity(int capacity) {
   Map* map = malloc(sizeof(Map));
   map->capacity = capacity;
   map->size = 0;
   // initialize to NULL, which means unused
-  map->pairs = calloc(map->capacity, sizeof *map->pairs);
+  map->pairs = calloc(map->capacity, sizeof(MapPair));
   return map;
 }
 
@@ -49,7 +49,7 @@ Map* create_map() {
 }
 
 void delete_map(Map* map) {
-  for (size_t i = 0; i < map->capacity; i++) {
+  for (int i = 0; i < map->capacity; i++) {
     if (map->pairs[i]) {
       delete_map_pair(map->pairs[i]);
       map->pairs[i] = NULL;
@@ -75,7 +75,7 @@ static int hash2(int n, int prime) {
 /// @brief A double hashing function that hashes the key into [0, capacity).
 /// @note Hashing is a large topic. This hash function is easy but may not be
 /// good.
-static int get_hashed_key(int key, size_t capacity, int attempt) {
+static int get_hashed_key(int key, int capacity, int attempt) {
   // the capacity we used is already a prime number
   int prime_1 = capacity;
   // a smaller prime in comparison with prime_1
@@ -121,7 +121,7 @@ static bool is_low_load(Map* map) {
 /// @note If the capacity is lower than MAP_BASE_CAPACITY, MAP_BASE_CAPACITY is
 /// used; if the capacity is not a prime number, the greater closet prime number
 /// is used.
-static void resize_map(Map* old, size_t capacity);
+static void resize_map(Map* old, int capacity);
 
 /// @details Double up the capacity if the map is under high load after the
 /// insertion.
@@ -159,7 +159,7 @@ void delete_pair(Map* map, int key) {
   }
 }
 
-static void resize_map(Map* old, size_t capacity) {
+static void resize_map(Map* old, int capacity) {
   if (capacity < MAP_BASE_CAPACITY) {
     capacity = MAP_BASE_CAPACITY;
   }
@@ -171,7 +171,7 @@ static void resize_map(Map* old, size_t capacity) {
   Map* new = create_map_with_capacity(capacity);
 
   // 2. Insert the pairs of the old map into the new map
-  for (size_t i = 0; i < old->capacity; i++) {
+  for (int i = 0; i < old->capacity; i++) {
     MapPair* item = old->pairs[i];
     if (item && item != PAIR_DELETED_MARKER) {
       insert_pair(new, item->key, item->val);

--- a/src/map.h
+++ b/src/map.h
@@ -25,7 +25,7 @@ void delete_map(Map*);
 /// @note The val may or may not be heap-allocated since the map does
 /// not take the ownership. If val is heap allocated, the caller has to free it
 /// manually.
-void insert_pair(Map* ht, int key, void* val);
+void insert_pair(Map*, int key, void* val);
 
 /// @return The val mapped by key; NULL if not exists.
 void* get_value(Map*, int key);
@@ -64,14 +64,14 @@ void to_next(MapIterator*);
 /// macro.
 /// @note This macro creates an iterator object internally and deletes it after
 /// the iteration is complete.
-#define FOR_EACH_ITR(map, itr_name, statement)        \
-  {                                                   \
-    MapIterator* itr_name = create_map_iterator(map); \
-    while (has_next(itr_name)) {                      \
-      to_next(itr_name);                              \
-      statement;                                      \
-    }                                                 \
-    delete_map_iterator(itr_name);                    \
+#define FOR_EACH_ITR(map, itr_name, statement)         \
+  {                                                    \
+    MapIterator*(itr_name) = create_map_iterator(map); \
+    while (has_next(itr_name)) {                       \
+      to_next(itr_name);                               \
+      statement;                                       \
+    }                                                  \
+    delete_map_iterator(itr_name);                     \
   }
 
 #endif /* end of include guard: MAP_H */

--- a/src/nfa.c
+++ b/src/nfa.c
@@ -6,7 +6,11 @@
 #include "map.h"
 #include "state.h"
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 Nfa* create_nfa(State* start, State* accept) {
+  // reason: a struct should be used in the case that parameters are
+  // easily swappable, but this function is exactly a
+  // creation of struct.
   Nfa* n = malloc(sizeof(Nfa));
   n->start = start;
   n->accept = accept;

--- a/src/state.c
+++ b/src/state.c
@@ -29,7 +29,7 @@ State* create_state(const int label, State** outs) {
   new_state->label = label;
   new_state->id = state_id++;
 
-  new_state->outs = malloc(sizeof *new_state->outs * num_of_outs(label));
+  new_state->outs = malloc(sizeof(State) * num_of_outs(label));
   if (label == ACCEPT) {
     new_state->outs[0] = NULL;
   } else {

--- a/test/map.h
+++ b/test/map.h
@@ -18,12 +18,12 @@ static void test_map_insert_and_search() {
   int keys[] = {9, 217, 100};
   int vals[] = {90, 2170, 1000};
 
-  for (size_t i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     insert_pair(map, keys[i], vals + i);
   }
 
   assert_int_equal(get_size(map), 3);
-  for (size_t i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     int* val = get_value(map, keys[i]);
     assert_non_null(val);
     assert_ptr_equal(val, vals + i);
@@ -38,7 +38,7 @@ void test_map_delete() {
   Map* map = create_map();
   int keys[] = {9, 100, 217};
   int vals[] = {90, 2170, 1000};
-  for (size_t i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     insert_pair(map, keys[i], vals + i);
   }
 
@@ -60,17 +60,17 @@ void test_map_capacity_should_grow() {
   };
   Map* map = create_map();
   int keys[NUM_OF_PAIRS];
-  for (size_t i = 0; i < NUM_OF_PAIRS; i++) {
+  for (int i = 0; i < NUM_OF_PAIRS; i++) {
     keys[i] = i;
   }
   int vals[NUM_OF_PAIRS];  // using the memory address, not initialized
 
-  for (size_t i = 0; i < NUM_OF_PAIRS; i++) {
+  for (int i = 0; i < NUM_OF_PAIRS; i++) {
     insert_pair(map, keys[i], vals + i);
   }
 
   assert_int_equal(get_size(map), NUM_OF_PAIRS);
-  for (size_t i = 0; i < NUM_OF_PAIRS; i++) {
+  for (int i = 0; i < NUM_OF_PAIRS; i++) {
     int* val = get_value(map, keys[i]);
     assert_non_null(val);
     assert_ptr_equal(vals + i, val);
@@ -84,7 +84,7 @@ static void test_map_iterator() {
   Map* map = create_map();
   int keys[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};  // as same as indices
   int vals[10];  // using the memory address, not initialized
-  for (size_t i = 0; i < 10; i++) {
+  for (int i = 0; i < 10; i++) {
     insert_pair(map, keys[i], vals + i);
   }
 

--- a/test/state.h
+++ b/test/state.h
@@ -26,7 +26,8 @@ static void test_create_labeled_state() {
 }
 
 static void test_create_epsilon_state() {
-  State out1, out2;  // ill-formed but doesn't matter
+  State out1;
+  State out2;  // ill-formed but doesn't matter
   State* outs[] = {&out1, &out2};
 
   State* epsilon_state = create_state(SPLIT, outs);


### PR DESCRIPTION
Fixes the bug-proneness reported by Clang-Tidy.

`size` & `capacity` of `Map` now has type `int` instead of `size_t`. Since this is an implementation detail, no API is changed.