### PR TITLE
Add lint CI on commits into main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run CLI tests on release build
         run: chmod +x ./cli_test.sh && ./cli_test.sh -r
   lint:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
     name: lint
     runs-on: ubuntu-22.04
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+      - name: Install cmocka
+        # clang-tidy requires code to be compilable
+        run: ./.github/scripts/install_cmocka.sh
       - name: Check coding styles
         run: make fmt FMTFLAGS='--dry-run --Werror'
       - name: Check naming conventions & bug-proneness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,15 @@ jobs:
         run: make valgrind
       - name: Run CLI tests on release build
         run: chmod +x ./cli_test.sh && ./cli_test.sh -r
+  lint:
+    if: github.ref == 'refs/heads/main'
+    name: lint
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Check coding styles
+        run: make fmt FMTFLAGS='--dry-run --Werror'
+      - name: Check naming conventions & bug-proneness
+        run: make tidy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Install cmocka
         # clang-tidy requires code to be compilable
-        run: ./.github/scripts/install_cmocka.sh
+        run: |
+          SCRIPT='./.github/scripts/install_cmocka.sh'
+          chmod +x "$SCRIPT" && "$SCRIPT"
       - name: Check coding styles
         run: make fmt FMTFLAGS='--dry-run --Werror'
       - name: Check naming conventions & bug-proneness

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ CFLAGS := $(STD) $(STACK) $(WARNS)
 DEBUG := -O0 -g3 -DDEBUG=1
 RELEASE := -O3
 
+# Flags for customizable format check, e.g., FMTFLAGS='--dry-run --Werror'
+FMTFLAGS := -i
+
 # Dependency libraries
 LIBS := -lm
 
@@ -148,8 +151,8 @@ valgrind:
 
 # Rule for formatting the source code with clang-format
 fmt:
-	@clang-format -i \
-		-style=file \
+	@clang-format -style=file \
+		$(FMTFLAGS) \
 		{$(SRCDIR),$(TESTDIR)}/*.{h,c}
 
 # Rule for enforcing naming conventions and checking proneness to bugs with clang-tidy


### PR DESCRIPTION
# Motivation

To ensure the quality of codes merging into the `main` branch, we would like to make some static checks, just with the tool we already have: *clang-format* & *clang-tidy*!

# What's new?

- Lint checking CI is triggered on pushes and pull requests into the `main` branch
- Target `fmt` in `Makefile` now executes with customizable flags