### PR TITLE
Fix incorrect short option for `--graph`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ bin/regexp -h # or --help
 ```
 regexp
 
-Usage: regexp [-h] [-V] [-d regexp [-o FILE]] [[-c] regexp string]
+Usage: regexp [-h] [-V] [-g regexp [-o FILE]] [[-c] regexp string]
 
 Description: Regular expression implementation.
 Supports . ( ) | * + ?. No escapes.
@@ -94,7 +94,7 @@ Graph mode:
   Converts the regular expression into a graph,
   exits with 1 if regexp is ill-formed or the file can't be opened
 
-  -d, --graph           Converts the NFA of the regexp into a Graphviz
+  -g, --graph           Converts the NFA of the regexp into a Graphviz
                         dot file (default: False)
   -o FILE, --output FILE
                         The name of the dot file.
@@ -112,7 +112,7 @@ Match mode:
 
 Written by: Lai-YT
 
-regexp version: 1.0.0
+regexp version: 1.0.2
 ```
 
 ### Example

--- a/src/messages.c
+++ b/src/messages.c
@@ -30,7 +30,7 @@ void help() {
  */
 void usage() {
   fprintf(stdout, YELLOW "Usage: " NO_COLOR);
-  fprintf(stdout, "%s [-h] [-V] [-d regexp [-o FILE]] [[-c] regexp string]\n\n",
+  fprintf(stdout, "%s [-h] [-V] [-g regexp [-o FILE]] [[-c] regexp string]\n\n",
           PROGRAM_NAME);
 }
 
@@ -58,7 +58,7 @@ void graph_mode() {
       "  Converts the regular expression into a graph,\n"
       "  exits with 1 if regexp is ill-formed or the file can't be opened\n"
       "\n"
-      "  -d, --graph           Converts the NFA of the regexp into a Graphviz\n"
+      "  -g, --graph           Converts the NFA of the regexp into a Graphviz\n"
       "                        dot file (default: False)\n"
       "  -o FILE, --output FILE\n"
       "                        The name of the dot file.\n"

--- a/src/messages.h
+++ b/src/messages.h
@@ -11,7 +11,7 @@ https://opensource.org/license/mit/.
 #define MESSAGES_H
 
 #define PROGRAM_NAME "regexp"
-#define PROGRAM_VERSION "1.0.1"
+#define PROGRAM_VERSION "1.0.2"
 #define PROGRAM_AUTHOR "Lai-YT"
 
 void help();


### PR DESCRIPTION
Fixes an error of the usage message.
The short option for `--graph` should be `-g` instead of `-d`.

This bumps the version to `1.0.2`.