### PR TITLE
Update usage message

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ $ bin/regexp -h # or --help
 ```
 regexp
 
-Usage: regexp [-h] [-V] [-g regexp [-o FILE]] [[-c] regexp string]
+Usage: regexp [-h] [-V] {-g regexp [-o FILE] | [-c] regexp string}
 
 Description: Regular expression implementation.
 Supports . ( ) | * + ?. No escapes.
 Compiles to NFA and then simulates NFA using Thompson's algorithm.
 
-One can either graph the regexp or match a string.
+One can either match a string (default) or graph the regexp.
 See the following options.
 Notice that character # can't appear in the regular expression,
 it's reserved technically as the special character.
@@ -89,6 +89,14 @@ it's reserved technically as the special character.
 Options:
   -h, --help            Shows this help message and exit
   -V, --version         Shows regexp version and exit
+
+Match mode:
+  Matches the string with the regular expression,
+  exits with 1 if regexp is ill-formed or it does not match
+
+  -c, --cache           Caches NFA states to build DFA on the fly
+  regexp                The regular expression to use on matching
+  string                The string to be matched
 
 Graph mode:
   Converts the regular expression into a graph,
@@ -101,14 +109,6 @@ Graph mode:
                         A .dot extension is appended automatically
                         (default: nfa)
   regexp                The regular expression to be converted
-
-Match mode:
-  Matches the string with the regular expression,
-  exits with 1 if regexp is ill-formed or it does not match
-
-  -c, --cache           Caches NFA states to build DFA on the fly
-  regexp                The regular expression to use on matching
-  string                The string to be matched
 
 Written by: Lai-YT
 

--- a/src/messages.c
+++ b/src/messages.c
@@ -30,7 +30,7 @@ void help() {
  */
 void usage() {
   fprintf(stdout, YELLOW "Usage: " NO_COLOR);
-  fprintf(stdout, "%s [-h] [-V] [-g regexp [-o FILE]] [[-c] regexp string]\n\n",
+  fprintf(stdout, "%s [-h] [-V] {-g regexp [-o FILE] | [-c] regexp string}\n\n",
           PROGRAM_NAME);
 }
 

--- a/src/messages.c
+++ b/src/messages.c
@@ -44,7 +44,7 @@ void description() {
           "Supports . ( ) | * + ?. No escapes.\n"
           "Compiles to NFA and then simulates NFA using Thompson's algorithm.\n"
           "\n"
-          "One can either graph the regexp or match a string.\n"
+          "One can either match a string (default) or graph the regexp.\n"
           "See the following options.\n"
           "Notice that character # can't appear in the regular expression,\n"
           "it's reserved technically as the special character.\n"
@@ -91,8 +91,8 @@ void options() {
           "  -V, --version         Shows %s version and exit\n"
           "\n" NO_COLOR,
           PROGRAM_NAME);
-  graph_mode();
   match_mode();
+  graph_mode();
 }
 
 /*


### PR DESCRIPTION
Since the user must choose one of the modes, using braces would better reveal the usage (see ["Usage Statements (Common Desktop Environment: Internationalization Programmer's Guide)"](https://docs.oracle.com/cd/E19455-01/806-2914/6jc3mhd5q/index.html)).
Also the *match* mode wasn't stated as default in the description, so add it. And show its options before other modes.
