### PR TITLE
Fix missing in-arrow to start state

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ This will then write the graph into `some/path/and/filename.dot`.
 ```console
 $ dot -Tpng nfa.dot -o nfa.png
 ```
-![The NFA of "(a|b)*abb"](https://imgur.com/WCbGHDu.png)
+![The NFA of "(a|b)*abb"](https://imgur.com/aVNvEoK.png)
 > [!note]
 > The numbering of the states is related to the order of their creations.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Graph mode:
 
 Written by: Lai-YT
 
-regexp version: 1.0.2
+regexp version: 1.0.3
 ```
 
 ### Example

--- a/src/messages.h
+++ b/src/messages.h
@@ -11,7 +11,7 @@ https://opensource.org/license/mit/.
 #define MESSAGES_H
 
 #define PROGRAM_NAME "regexp"
-#define PROGRAM_VERSION "1.0.2"
+#define PROGRAM_VERSION "1.0.3"
 #define PROGRAM_AUTHOR "Lai-YT"
 
 void help();

--- a/src/visstate.c
+++ b/src/visstate.c
@@ -50,5 +50,9 @@ void nfa2dot(const Nfa* nfa, FILE* f) {
   fprintf(f, "\tnode [shape = doublecircle]; %d;\n", nfa->accept->id);
   fputs("\tnode [shape = circle];\n", f);
   states2dot(nfa->start, f);
+  // Generate an in-arrow to the start state.
+  // The name is irrelevant since it won't be displayed.
+  fputs("\tstart [shape = none, label = \"\"];\n", f);
+  fprintf(f, "\tstart -> %d\n", nfa->start->id);
   fputs("}\n", f);
 }

--- a/src/visstate.c
+++ b/src/visstate.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
 #include "map.h"
-#include "post2nfa.h"
+#include "nfa.h"
 #include "stack.h"
 
 /// @details The label of an epsilon transition is "eps", others are the


### PR DESCRIPTION
The start state is often not numbered as `0` due to the order of state creation, but by default, the start state should be `0` if no in-arrow is specified. This PR adds an explicit in-arrow to the start state to ensure correctness.

This bumps the version to `1.0.3`.